### PR TITLE
Remove warning for node 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: circleci/node:8.9.1
+    - image: circleci/node:12
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Requirements
 
 `univapay-node` requires the following to run:
 
-  * [Node.js][node] 8.0+
+  * [Node.js][node] 10 or 12
   * [npm][npm] (normally comes with Node.js) or [yarn][yarn]
 
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     },
     "bugs": "https://github.com/univapay/univapay-node/issues",
     "engines": {
-        "node": "10.x.x"
+        "node": "^10 || ^12"
     },
     "sideEffects": false,
     "main": "index.js",


### PR DESCRIPTION
As the package is stable with node 12, remove the warning.