### PR TITLE
Allow modifying the poll success condition

### DIFF
--- a/src/resources/Cancels.ts
+++ b/src/resources/Cancels.ts
@@ -80,10 +80,10 @@ export class Cancels extends CRUDResource {
          * Condition to cancel the polling and return `null`,
          */
         cancelCondition?: (response: ResponseCancel) => boolean,
+        successCondition: ({ status }: ResponseCancel) => boolean = ({ status }) => status !== CancelStatus.PENDING,
     ): Promise<ResponseCancel> {
         const pollingData = { ...data, polling: true };
         const promise: () => Promise<ResponseCancel> = () => this.get(storeId, chargeId, id, pollingData);
-        const successCondition = ({ status }: ResponseCancel) => status !== CancelStatus.PENDING;
 
         return this.api.longPolling(promise, successCondition, cancelCondition, callback);
     }

--- a/src/resources/Charges.ts
+++ b/src/resources/Charges.ts
@@ -107,10 +107,10 @@ export class Charges extends CRUDResource {
          * Condition for the resource to be successfully loaded. Default to pending status check.
          */
         cancelCondition?: (response: ResponseCharge) => boolean,
+        successCondition: ({ status }: ResponseCharge) => boolean = ({ status }) => status !== ChargeStatus.PENDING,
     ): Promise<ResponseCharge> {
         const pollingData = { ...data, polling: true };
         const promise: () => Promise<ResponseCharge> = () => this.get(storeId, id, pollingData);
-        const successCondition = ({ status }: ResponseCharge) => status !== ChargeStatus.PENDING;
 
         return this.api.longPolling(promise, successCondition, cancelCondition, callback);
     }

--- a/src/resources/Refunds.ts
+++ b/src/resources/Refunds.ts
@@ -114,10 +114,10 @@ export class Refunds extends CRUDResource {
          * Condition for the resource to be successfully loaded. Default to pending status check.
          */
         cancelCondition?: (response: ResponseRefund) => boolean,
+        successCondition: ({ status }: ResponseRefund) => boolean = ({ status }) => status !== RefundStatus.PENDING,
     ): Promise<ResponseRefund> {
         const pollData = { ...data, polling: true };
         const promise: () => Promise<ResponseRefund> = () => this.get(storeId, chargeId, id, pollData);
-        const successCondition = ({ status }: ResponseRefund) => status !== RefundStatus.PENDING;
 
         return this.api.longPolling(promise, successCondition, cancelCondition, callback);
     }

--- a/src/resources/Subscriptions.ts
+++ b/src/resources/Subscriptions.ts
@@ -340,10 +340,11 @@ export class Subscriptions extends CRUDResource {
          * Condition for the resource to be successfully loaded. Default to pending status check.
          */
         cancelCondition?: (response: ResponseSubscription) => boolean,
+        successCondition: ({ status }: ResponseSubscription) => boolean = ({ status }) =>
+            status !== SubscriptionStatus.UNVERIFIED,
     ): Promise<ResponseSubscription> {
         const pollData = { ...data, polling: true };
         const promise: () => Promise<ResponseSubscription> = () => this.get(storeId, id, pollData);
-        const successCondition = ({ status }: ResponseSubscription) => status !== SubscriptionStatus.UNVERIFIED;
 
         return this.api.longPolling(promise, successCondition, cancelCondition, callback);
     }


### PR DESCRIPTION
Updates https://github.com/univapaycast/univapay-console/issues/2035

Allows to modify the poll success method. On capture creation we want to wait until the charge is not in the capture state anymore and it does not goes into the `pending` state. The rest of the update is to keep the function consistent as they are of same nature.