### PR TITLE
Feature/laxa88/noqa/api error update

### DIFF
--- a/src/errors/parser.ts
+++ b/src/errors/parser.ts
@@ -43,7 +43,7 @@ export function fromError(error: Error): RequestResponseBaseError {
         return new ResponseError({
             code: error.response ? error.response.code : getCodeByStatus(error.status),
             httpCode: error.status,
-            errors: error.response ? error.response.errors || [] : [],
+            errors: error.response ? error.response.errors || error.response : [],
         });
     }
 

--- a/src/resources/Resource.ts
+++ b/src/resources/Resource.ts
@@ -10,15 +10,35 @@ import { missingKeys } from '../utils/object';
 
 export type DefinedRoute = (data?: any, callback?: any, pathParams?: string[], ...params: string[]) => Promise<any>;
 
-function compilePath(path: string, pathParams: any): string {
+/**
+ * Returns a path with pathParams filled into `:paramName`.
+ *
+ * If the path is wrapped in `()`, the path within will
+ * be omitted if one or more required params are missing.
+ *
+ * e.g.
+ * ```
+ * path = "(/merchant/:merchantId/store/:storeId)/platforms"
+ * pathParams = { merchantId: "123" }
+ * // result: "/platforms"
+ *
+ * path = "(/merchant/:merchantId/store/:storeId)/platforms"
+ * pathParams = { merchantId: "123", storeId: "456" }
+ * // result: "merchant/123/store/456/platforms"
+ * ```
+ *
+ * @param path The full path to compile, e.g. `(/merchant/:merchantId)/store/:storeId`
+ * @param pathParams Object of params to fill into the path, e.g. `{ merchantId: "abc" }`
+ */
+function compilePath(path: string, pathParams: Record<string, any>): string {
     return path
         .replace(/\((\w|:|\/)+\)/gi, (o: string) => {
             const part: string = o.replace(/:(\w+)/gi, (s: string, p: string) => {
-                return (pathParams as any)[p] || s;
+                return pathParams[p] || s;
             });
             return part.indexOf(':') === -1 ? part.replace(/\(|\)/g, '') : '';
         })
-        .replace(/:(\w+)/gi, (s: string, p: string) => (pathParams as any)[p] || s);
+        .replace(/:(\w+)/gi, (s: string, p: string) => pathParams[p] || s);
 }
 
 export abstract class Resource {

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -27,7 +27,10 @@ export function transformKeys(obj: any, transformer: Transformer, ignoreKeys: st
     }, {});
 }
 
-export function missingKeys(obj: any, keys: string[] = []): string[] {
+/**
+ * Returns a list from `keys` that are not found in `obj`
+ */
+export function missingKeys(obj: Record<string, any>, keys: string[] = []): string[] {
     if (!obj) {
         return keys;
     }


### PR DESCRIPTION
Updates https://github.com/univapaycast/univapay-admin-console/pull/319
Updates https://github.com/univapaycast/univapay-admin-console/issues/277

Previously, errors are expected to have a `errors` property, otherwise an empty `[]` is returned. This PR updates the response to return the body (if it exists) as a fallback instead of `[]`.