### PR TITLE
Add EventEmitter to SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1979,6 +1979,11 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "eventemitter3": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+      "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
+    },
     "execa": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   "dependencies": {
     "camelcase": "^6.0.0",
     "decamelize": "^4.0.0",
+    "eventemitter3": "^4.0.4",
     "flat": "^5.0.0",
     "isomorphic-fetch": "^2.2.1",
     "isomorphic-form-data": "^2.0.0",

--- a/test/specs/api.specs.ts
+++ b/test/specs/api.specs.ts
@@ -202,7 +202,6 @@ describe("API", function () {
         await api.send(HTTPMethod.GET, "/ok");
 
         expect(onResponse).to.have.been.calledOnce;
-        console.log(onResponse.firstCall.lastArg);
         expect(onResponse.firstCall.lastArg)
             .to.include({
                 status: 200,

--- a/test/specs/api.specs.ts
+++ b/test/specs/api.specs.ts
@@ -166,6 +166,52 @@ describe("API", function () {
         }
     });
 
+    it("should emit request event", async function () {
+        fetchMock.getOnce(`${testEndpoint}/ok`, {
+            status: 200,
+            body: okResponse,
+            headers: { "Content-Type": "application/json" },
+        });
+
+        const onRequest = sinon.spy();
+
+        const api: RestAPI = new RestAPI({ endpoint: testEndpoint });
+        api.on("request", onRequest);
+        await api.send(HTTPMethod.GET, "/ok");
+
+        expect(onRequest).to.have.been.calledOnce;
+        expect(onRequest.firstCall.lastArg).to.include({
+            path: "/ok",
+            method: "GET",
+            url: "http://mock-api/ok",
+            body: undefined,
+        });
+    });
+
+    it("should emit response event", async function () {
+        fetchMock.getOnce(`${testEndpoint}/ok`, {
+            status: 200,
+            body: okResponse,
+            headers: { "Content-Type": "application/json" },
+        });
+
+        const onResponse = sinon.spy();
+
+        const api: RestAPI = new RestAPI({ endpoint: testEndpoint });
+        api.on("response", onResponse);
+        await api.send(HTTPMethod.GET, "/ok");
+
+        expect(onResponse).to.have.been.calledOnce;
+        console.log(onResponse.firstCall.lastArg);
+        expect(onResponse.firstCall.lastArg)
+            .to.include({
+                status: 200,
+                statusText: "OK",
+            })
+            .and.have.property("body")
+            .eql(Buffer.from(JSON.stringify(okResponse)));
+    });
+
     it("should send request with Origin header", async function () {
         interface Origin {
             origin?: string;


### PR DESCRIPTION
Closes #35 

Uses [eventemitter3](https://github.com/primus/eventemitter3), and is completely type-safe
Super straightforward :D