### PR TITLE
Support event emitters from PaymentsSDK and Resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,18 @@ const customSdk = new CustomSDK();
 
 ### API Documentation
 
+#### Events
+
+The `PaymentsSDK` and `Resource` based classes such as `Charges` and `Stores` are [EventEmitters](https://nodejs.org/api/events.html). You can subscribe to the following events:
+
+```
+const sdk = new SDK();
+sdk.on('request', (req: Request) => void)
+sdk.on('response', (res: Response) => void)
+```
+
+`Request` and `Response` are the [`fetch` API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) types.
+
 WIP
 
 ### TypeScript

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ const customSdk = new CustomSDK();
 
 The `PaymentsSDK` and `Resource` based classes such as `Charges` and `Stores` are [EventEmitters](https://nodejs.org/api/events.html). You can subscribe to the following events:
 
-```
+```javascript
 const sdk = new SDK();
 sdk.on('request', (req: Request) => void)
 sdk.on('response', (res: Response) => void)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1979,11 +1979,6 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
-    "eventemitter3": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-      "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
-    },
     "events": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1984,6 +1984,11 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
       "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
     },
+    "events": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
+      "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg=="
+    },
     "execa": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
   "dependencies": {
     "camelcase": "^6.0.0",
     "decamelize": "^4.0.0",
-    "eventemitter3": "^4.0.4",
     "events": "^3.2.0",
     "flat": "^5.0.0",
     "isomorphic-fetch": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "camelcase": "^6.0.0",
     "decamelize": "^4.0.0",
     "eventemitter3": "^4.0.4",
+    "events": "^3.2.0",
     "flat": "^5.0.0",
     "isomorphic-fetch": "^2.2.1",
     "isomorphic-form-data": "^2.0.0",

--- a/src/api/RestAPI.ts
+++ b/src/api/RestAPI.ts
@@ -3,7 +3,7 @@
  */
 
 import decamelize from "decamelize";
-import EventEmitter from "eventemitter3";
+import { EventEmitter } from "events";
 import { stringify as stringifyQuery } from "query-string";
 
 import "isomorphic-fetch";
@@ -115,11 +115,6 @@ export type PromiseCreator<A> = () => Promise<A>;
 
 export type SendData<Data> = Data & AuthParams & IdempotentParams & OriginParams;
 
-export type APIEvents = {
-    request: (req: Request) => void;
-    response: (res: Response) => void;
-};
-
 function getData<Data extends Record<string, any>>(
     data: SendData<Data>
 ): Omit<Data, keyof AuthParams | keyof IdempotentParams | keyof OriginParams> {
@@ -162,7 +157,7 @@ async function execRequest<A>(executor: () => Promise<A>, callback?: ResponseCal
     }
 }
 
-export class RestAPI extends EventEmitter<APIEvents> {
+export class RestAPI extends EventEmitter {
     endpoint: string;
     jwt: JWTPayload<any>;
     origin: string;

--- a/src/resources/Resource.ts
+++ b/src/resources/Resource.ts
@@ -2,6 +2,8 @@
  *  @internal
  *  @module Resources
  */
+import { EventEmitter } from "events";
+
 import { HTTPMethod, ResponseCallback, RestAPI, SendData } from "../api/RestAPI";
 import { fromError } from "../errors/parser";
 import { PathParameterError } from "../errors/PathParameterError";
@@ -41,11 +43,15 @@ function compilePath(path: string, pathParams: Record<string, any>): string {
         .replace(/:(\w+)/gi, (s: string, p: string) => pathParams[p] || s);
 }
 
-export abstract class Resource {
+export abstract class Resource extends EventEmitter {
     protected api: RestAPI;
 
     constructor(api: RestAPI) {
+        super();
+
         this.api = api;
+        this.on("newListener", (event, listener) => api.on(event, listener));
+        this.on("removeListener", (event, listener) => api.removeListener(event, listener));
     }
 
     protected defineRoute(

--- a/src/sdk/PaymentsSDK.ts
+++ b/src/sdk/PaymentsSDK.ts
@@ -2,12 +2,18 @@
  *  @module SDK
  */
 
+import { EventEmitter } from "events";
+
 import { RestAPI, RestAPIOptions } from "../api/RestAPI";
 
-export abstract class PaymentsSDK {
+export abstract class PaymentsSDK extends EventEmitter {
     api: RestAPI;
 
     constructor(options?: RestAPIOptions) {
+        super();
+
         this.api = new RestAPI(options);
+        this.on("newListener", (event, listener) => this.api.on(event, listener));
+        this.on("removeListener", (event, listener) => this.api.removeListener(event, listener));
     }
 }


### PR DESCRIPTION
Closes #38 

This works by using the [`newListener`](https://nodejs.org/api/events.html#events_event_newlistener) and [`removeListener`](https://nodejs.org/api/events.html#events_event_removelistener) events - whenever the `Resource` or `PaymentsSDK` gets an event handler, it is relayed to the underlying `api` object.
However, [`eventemitter3` doesn't support these built-in events](https://github.com/primus/eventemitter3/issues/50), so it had to be replaced with a more straightforward [`node` polyfill](https://www.npmjs.com/package/events). The good thing here is that in node environments, we'll just keep using the regular node module. The bad news is that [standard node typings](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/v12/events.d.ts) are not as strict as the [`eventemitter3` typings](https://github.com/primus/eventemitter3/blob/master/index.d.ts) - these do not support generics, so the events are not type safe anymore.