### PR TITLE
Override auth parameters on individual api calls

### DIFF
--- a/src/api/RestAPI.ts
+++ b/src/api/RestAPI.ts
@@ -209,6 +209,7 @@ export class RestAPI extends EventEmitter {
         method: HTTPMethod,
         uri: string,
         data?: SendData<Data>,
+        auth?: AuthParams,
         callback?: ResponseCallback<A>,
         requireAuth = true,
         acceptType?: string
@@ -226,7 +227,7 @@ export class RestAPI extends EventEmitter {
         const payload: boolean = [HTTPMethod.GET, HTTPMethod.DELETE].indexOf(method) === -1;
 
         const params: RequestInit = {
-            headers: this.getHeaders(data, payload, acceptType),
+            headers: this.getHeaders(data, auth, payload, acceptType),
             method,
         };
 
@@ -243,7 +244,7 @@ export class RestAPI extends EventEmitter {
 
             this.emit("response", response);
 
-            const jwt = await extractJWT(response);
+            const jwt = extractJWT(response);
 
             if (jwt) {
                 this.jwtRaw = jwt;
@@ -274,6 +275,7 @@ export class RestAPI extends EventEmitter {
 
     protected getHeaders<Data extends Record<string, any>>(
         data: SendData<Data>,
+        auth: AuthParams,
         payload: boolean,
         acceptType = "application/json"
     ): Headers {
@@ -298,6 +300,7 @@ export class RestAPI extends EventEmitter {
 
         // Deprecated
         const { authToken = this.authToken, appId = this.appId, secret = this.secret, jwt = this.jwtRaw } = {
+            ...auth,
             ...(!isFormData ? data : {}),
         };
 
@@ -356,6 +359,6 @@ export class RestAPI extends EventEmitter {
     }
 
     async ping(callback?: ResponseCallback<void>): Promise<void> {
-        await this.send(HTTPMethod.GET, "/heartbeat", null, callback, false);
+        await this.send(HTTPMethod.GET, "/heartbeat", null, null, callback, false);
     }
 }

--- a/src/api/RestAPI.ts
+++ b/src/api/RestAPI.ts
@@ -298,10 +298,9 @@ export class RestAPI extends EventEmitter {
             headers.append(IDEMPOTENCY_KEY_HEADER, idempotentKey);
         }
 
-        // Deprecated
         const { authToken = this.authToken, appId = this.appId, secret = this.secret, jwt = this.jwtRaw } = {
-            ...auth,
             ...(!isFormData ? data : {}),
+            ...auth,
         };
 
         if (authToken) {

--- a/src/resources/BankAccounts.ts
+++ b/src/resources/BankAccounts.ts
@@ -2,7 +2,7 @@
  *  @module Resources/BankAccounts
  */
 
-import { ErrorResponse, HTTPMethod, ResponseCallback, SendData } from "../api/RestAPI";
+import { AuthParams, ErrorResponse, HTTPMethod, ResponseCallback, SendData } from "../api/RestAPI";
 
 import { CRUDItemsResponse, CRUDPaginationParams, CRUDResource } from "./CRUDResource";
 
@@ -80,32 +80,44 @@ export class BankAccounts extends CRUDResource {
 
     create(
         data: SendData<BankAccountCreateParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseBankAccount>
     ): Promise<ResponseBankAccount> {
-        return this._createRoute(BankAccounts.requiredParams)(data, callback);
+        return this._createRoute(BankAccounts.requiredParams)(data, callback, auth);
     }
 
     get(
         id: string,
         data?: SendData<void>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseBankAccount>
     ): Promise<ResponseBankAccount> {
-        return this._getRoute()(data, callback, ["id"], id);
+        return this._getRoute()(data, callback, auth, { id });
     }
 
     update(
         id: string,
         data?: SendData<BankAccountUpdateParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseBankAccount>
     ): Promise<ResponseBankAccount> {
-        return this._updateRoute()(data, callback, ["id"], id);
+        return this._updateRoute()(data, callback, auth, { id });
     }
 
-    delete(id: string, data?: SendData<void>, callback?: ResponseCallback<ErrorResponse>): Promise<ErrorResponse> {
-        return this._deleteRoute()(data, callback, ["id"], id);
+    delete(
+        id: string,
+        data?: SendData<void>,
+        auth?: AuthParams,
+        callback?: ResponseCallback<ErrorResponse>
+    ): Promise<ErrorResponse> {
+        return this._deleteRoute()(data, callback, auth, { id });
     }
 
-    getPrimary(data?: SendData<void>, callback?: ResponseCallback<ResponseBankAccount>): Promise<ResponseBankAccount> {
-        return this.defineRoute(HTTPMethod.GET, `${this._routeBase}/primary`)(data, callback);
+    getPrimary(
+        data?: SendData<void>,
+        auth?: AuthParams,
+        callback?: ResponseCallback<ResponseBankAccount>
+    ): Promise<ResponseBankAccount> {
+        return this.defineRoute(HTTPMethod.GET, `${this._routeBase}/primary`)(data, callback, auth);
     }
 }

--- a/src/resources/Cancels.ts
+++ b/src/resources/Cancels.ts
@@ -2,7 +2,7 @@
  *  @module Resources/Cancels
  */
 
-import { PollParams, ResponseCallback, SendData } from "../api/RestAPI";
+import { AuthParams, PollParams, ResponseCallback, SendData } from "../api/RestAPI";
 
 import { ProcessingMode } from "./common/enums";
 import { Metadata, PaymentError } from "./common/types";
@@ -48,18 +48,20 @@ export class Cancels extends CRUDResource {
         storeId: string,
         chargeId: string,
         data?: SendData<CancelsListParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseCancels>
     ): Promise<ResponseCancels> {
-        return this._listRoute()(data, callback, ["storeId", "chargeId"], storeId, chargeId);
+        return this._listRoute()(data, callback, auth, { storeId, chargeId });
     }
 
     create(
         storeId: string,
         chargeId: string,
         data: SendData<CancelCreateParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseCancel>
     ): Promise<ResponseCancel> {
-        return this._createRoute(Cancels.requiredParams)(data, callback, ["storeId", "chargeId"], storeId, chargeId);
+        return this._createRoute(Cancels.requiredParams)(data, callback, auth, { storeId, chargeId });
     }
 
     get(
@@ -67,9 +69,10 @@ export class Cancels extends CRUDResource {
         chargeId: string,
         id: string,
         data?: SendData<PollParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseCancel>
     ): Promise<ResponseCancel> {
-        return this._getRoute()(data, callback, ["storeId", "chargeId", "id"], storeId, chargeId, id);
+        return this._getRoute()(data, callback, auth, { storeId, chargeId, id });
     }
 
     poll(
@@ -77,6 +80,7 @@ export class Cancels extends CRUDResource {
         chargeId: string,
         id: string,
         data?: SendData<PollParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseCancel>,
 
         /**
@@ -86,7 +90,7 @@ export class Cancels extends CRUDResource {
         successCondition: ({ status }: ResponseCancel) => boolean = ({ status }) => status !== CancelStatus.PENDING
     ): Promise<ResponseCancel> {
         const pollingData = { ...data, polling: true };
-        const promise: () => Promise<ResponseCancel> = () => this.get(storeId, chargeId, id, pollingData);
+        const promise: () => Promise<ResponseCancel> = () => this.get(storeId, chargeId, id, pollingData, auth);
 
         return this.api.longPolling(promise, successCondition, cancelCondition, callback);
     }

--- a/src/resources/Captures.ts
+++ b/src/resources/Captures.ts
@@ -2,7 +2,7 @@
  *  @module Resources/Captures
  */
 
-import { ResponseCallback, SendData } from "../api/RestAPI";
+import { AuthParams, ResponseCallback, SendData } from "../api/RestAPI";
 
 import { CRUDResource } from "./CRUDResource";
 
@@ -29,8 +29,9 @@ export class Captures extends CRUDResource {
         storeId: string,
         chargeId: string,
         data: SendData<CaptureCreateParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<any>
     ): Promise<any> {
-        return this._createRoute(Captures.requiredParams)(data, callback, ["storeId", "chargeId"], storeId, chargeId);
+        return this._createRoute(Captures.requiredParams)(data, callback, auth, { storeId, chargeId });
     }
 }

--- a/src/resources/Charges.ts
+++ b/src/resources/Charges.ts
@@ -2,7 +2,7 @@
  *  @module Resources/Charges
  */
 
-import { HTTPMethod, PollParams, ResponseCallback, SendData } from "../api/RestAPI";
+import { AuthParams, HTTPMethod, PollParams, ResponseCallback, SendData } from "../api/RestAPI";
 
 import { ProcessingMode } from "./common/enums";
 import { ignoreDescriptor } from "./common/ignoreDescriptor";
@@ -83,19 +83,21 @@ export class Charges extends CRUDResource {
 
     list(
         data?: SendData<ChargesListParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseCharges>,
         storeId?: string
     ): Promise<ResponseCharges> {
-        return this.defineRoute(HTTPMethod.GET, "(/stores/:storeId)/charges")(data, callback, ["storeId"], storeId);
+        return this.defineRoute(HTTPMethod.GET, "(/stores/:storeId)/charges")(data, callback, auth, { storeId });
     }
 
     async create(
         data: SendData<ChargeCreateParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseCharge>
     ): Promise<ResponseCharge> {
         return ignoreDescriptor(
             (updatedData: ChargeCreateParams) =>
-                this.defineRoute(HTTPMethod.POST, "/charges", Charges.requiredParams)(updatedData, callback),
+                this.defineRoute(HTTPMethod.POST, "/charges", Charges.requiredParams)(updatedData, callback, auth),
             data
         );
     }
@@ -104,23 +106,24 @@ export class Charges extends CRUDResource {
         storeId: string,
         id: string,
         data?: SendData<PollParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseCharge>
     ): Promise<ResponseCharge> {
-        return this._getRoute()(data, callback, ["storeId", "id"], storeId, id);
+        return this._getRoute()(data, callback, auth, { storeId, id });
     }
 
     getIssuerToken(
         storeId: string,
         chargeId: string,
         data?: SendData<ChargeIssuerTokenGetParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseIssuerToken>
     ): Promise<ResponseIssuerToken> {
         return this.defineRoute(HTTPMethod.GET, "/stores/:storeId/charges/:chargeId/issuerToken")(
             data,
             callback,
-            ["storeId", "chargeId"],
-            storeId,
-            chargeId
+            auth,
+            { storeId, chargeId }
         );
     }
 
@@ -128,6 +131,7 @@ export class Charges extends CRUDResource {
         storeId: string,
         id: string,
         data?: SendData<PollParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseCharge>,
 
         /**
@@ -137,7 +141,7 @@ export class Charges extends CRUDResource {
         successCondition: ({ status }: ResponseCharge) => boolean = ({ status }) => status !== ChargeStatus.PENDING
     ): Promise<ResponseCharge> {
         const pollingData = { ...data, polling: true };
-        const promise: () => Promise<ResponseCharge> = () => this.get(storeId, id, pollingData);
+        const promise: () => Promise<ResponseCharge> = () => this.get(storeId, id, pollingData, auth);
 
         return this.api.longPolling(promise, successCondition, cancelCondition, callback);
     }

--- a/src/resources/CheckoutInfo.ts
+++ b/src/resources/CheckoutInfo.ts
@@ -2,7 +2,7 @@
  *  @module Resources/CheckoutInfo
  */
 
-import { HTTPMethod, ResponseCallback, SendData } from "../api/RestAPI";
+import { AuthParams, HTTPMethod, ResponseCallback, SendData } from "../api/RestAPI";
 
 import {
     CardConfigurationItem,
@@ -67,8 +67,9 @@ export type ResponseCheckoutInfo = CheckoutInfoItem;
 export class CheckoutInfo extends Resource {
     get(
         data?: SendData<CheckoutInfoParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseCheckoutInfo>
     ): Promise<ResponseCheckoutInfo> {
-        return this.defineRoute(HTTPMethod.GET, "/checkout_info")(data, callback);
+        return this.defineRoute(HTTPMethod.GET, "/checkout_info")(data, callback, auth);
     }
 }

--- a/src/resources/ExchangeRates.ts
+++ b/src/resources/ExchangeRates.ts
@@ -1,5 +1,5 @@
 /* Request */
-import { HTTPMethod, ResponseCallback, SendData } from "../api/RestAPI";
+import { AuthParams, HTTPMethod, ResponseCallback, SendData } from "../api/RestAPI";
 
 import { Resource } from "./Resource";
 
@@ -20,8 +20,9 @@ export type ResponseExchangeRate = ExchangeRateItem;
 export class ExchangeRates extends Resource {
     calculate(
         data: SendData<ExchangeRateParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseExchangeRate>
     ): Promise<ResponseExchangeRate> {
-        return this.defineRoute(HTTPMethod.POST, "/exchange_rates/calculate")(data, callback);
+        return this.defineRoute(HTTPMethod.POST, "/exchange_rates/calculate")(data, callback, auth);
     }
 }

--- a/src/resources/Ledgers.ts
+++ b/src/resources/Ledgers.ts
@@ -2,7 +2,7 @@
  *  @module Resources/Ledgers
  */
 
-import { HTTPMethod, ResponseCallback, SendData } from "../api/RestAPI";
+import { AuthParams, HTTPMethod, ResponseCallback, SendData } from "../api/RestAPI";
 
 import { CRUDItemsResponse, CRUDPaginationParams, CRUDResource } from "./CRUDResource";
 
@@ -52,12 +52,18 @@ export class Ledgers extends CRUDResource {
     list(
         transferId: string,
         data?: LedgersListParams,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseLedgers>
     ): Promise<ResponseLedgers> {
-        return this._listRoute()(data, callback, ["transferId"], transferId);
+        return this._listRoute()(data, callback, auth, { transferId });
     }
 
-    get(id: string, data?: SendData<void>, callback?: ResponseCallback<ResponseLedger>): Promise<ResponseLedger> {
-        return this.defineRoute(HTTPMethod.GET, "/ledgers/:id")(data, callback, ["id"], id);
+    get(
+        id: string,
+        data?: SendData<void>,
+        auth?: AuthParams,
+        callback?: ResponseCallback<ResponseLedger>
+    ): Promise<ResponseLedger> {
+        return this.defineRoute(HTTPMethod.GET, "/ledgers/:id")(data, callback, auth, { id });
     }
 }

--- a/src/resources/Merchants.ts
+++ b/src/resources/Merchants.ts
@@ -2,7 +2,7 @@
  *  @module Resources/Merchants
  */
 
-import { HTTPMethod, ResponseCallback, SendData } from "../api/RestAPI";
+import { AuthParams, HTTPMethod, ResponseCallback, SendData } from "../api/RestAPI";
 
 import { ConfigurationItem } from "./common/Configuration";
 import { TransferScheduleItem } from "./common/TransferSchedule";
@@ -33,7 +33,11 @@ export interface MerchantBanParams {
 }
 
 export class Merchants extends CRUDResource {
-    me(data?: SendData<void>, callback?: ResponseCallback<ResponseMerchant>): Promise<ResponseMerchant> {
-        return this.defineRoute(HTTPMethod.GET, "/me")(data, callback);
+    me(
+        data?: SendData<void>,
+        auth?: AuthParams,
+        callback?: ResponseCallback<ResponseMerchant>
+    ): Promise<ResponseMerchant> {
+        return this.defineRoute(HTTPMethod.GET, "/me")(data, callback, auth);
     }
 }

--- a/src/resources/Platforms.ts
+++ b/src/resources/Platforms.ts
@@ -2,7 +2,7 @@
  *  @module Resources/Platforms
  */
 
-import { HTTPMethod, ResponseCallback, SendData } from "../api/RestAPI";
+import { AuthParams, HTTPMethod, ResponseCallback, SendData } from "../api/RestAPI";
 
 import { CardBrand } from "./common/enums";
 import { PlatformConfiguration as PlatformConfig, PlatformItem } from "./common/Platform";
@@ -23,8 +23,9 @@ export type ResponsePlatformConfiguration = Readonly<PlatformConfigurationItem>;
 export class Platforms extends CRUDResource {
     getConfiguration(
         data?: SendData<void>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponsePlatformConfiguration>
     ): Promise<ResponsePlatformConfiguration> {
-        return this.defineRoute(HTTPMethod.GET, "/platform", undefined, false)(data, callback);
+        return this.defineRoute(HTTPMethod.GET, "/platform", undefined, false)(data, callback, auth);
     }
 }

--- a/src/resources/Refunds.ts
+++ b/src/resources/Refunds.ts
@@ -2,7 +2,7 @@
  *  @module Resources/Refunds
  */
 
-import { PollParams, ResponseCallback, SendData } from "../api/RestAPI";
+import { AuthParams, PollParams, ResponseCallback, SendData } from "../api/RestAPI";
 
 import { ProcessingMode } from "./common/enums";
 import { Metadata, PaymentError } from "./common/types";
@@ -72,18 +72,20 @@ export class Refunds extends CRUDResource {
         storeId: string,
         chargeId: string,
         data?: SendData<RefundsListParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseRefunds>
     ): Promise<ResponseRefunds> {
-        return this._listRoute()(data, callback, ["storeId", "chargeId"], storeId, chargeId);
+        return this._listRoute()(data, callback, auth, { storeId, chargeId });
     }
 
     create(
         storeId: string,
         chargeId: string,
         data: SendData<RefundCreateParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseRefund>
     ): Promise<ResponseRefund> {
-        return this._createRoute(Refunds.requiredParams)(data, callback, ["storeId", "chargeId"], storeId, chargeId);
+        return this._createRoute(Refunds.requiredParams)(data, callback, auth, { storeId, chargeId });
     }
 
     get(
@@ -91,9 +93,10 @@ export class Refunds extends CRUDResource {
         chargeId: string,
         id: string,
         data?: SendData<PollParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseRefund>
     ): Promise<ResponseRefund> {
-        return this._getRoute()(data, callback, ["storeId", "chargeId", "id"], storeId, chargeId, id);
+        return this._getRoute()(data, callback, auth, { storeId, chargeId, id });
     }
 
     update(
@@ -101,9 +104,10 @@ export class Refunds extends CRUDResource {
         chargeId: string,
         id: string,
         data?: SendData<RefundUpdateParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseRefund>
     ): Promise<ResponseRefund> {
-        return this._updateRoute()(data, callback, ["storeId", "chargeId", "id"], storeId, chargeId, id);
+        return this._updateRoute()(data, callback, auth, { storeId, chargeId, id });
     }
 
     poll(
@@ -111,6 +115,7 @@ export class Refunds extends CRUDResource {
         chargeId: string,
         id: string,
         data?: SendData<PollParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseRefund>,
 
         /**
@@ -120,7 +125,7 @@ export class Refunds extends CRUDResource {
         successCondition: ({ status }: ResponseRefund) => boolean = ({ status }) => status !== RefundStatus.PENDING
     ): Promise<ResponseRefund> {
         const pollData = { ...data, polling: true };
-        const promise: () => Promise<ResponseRefund> = () => this.get(storeId, chargeId, id, pollData);
+        const promise: () => Promise<ResponseRefund> = () => this.get(storeId, chargeId, id, pollData, auth);
 
         return this.api.longPolling(promise, successCondition, cancelCondition, callback);
     }

--- a/src/resources/Stores.ts
+++ b/src/resources/Stores.ts
@@ -2,7 +2,7 @@
  *  @module Resources/Stores
  */
 
-import { ErrorResponse, ResponseCallback, SendData } from "../api/RestAPI";
+import { AuthParams, ErrorResponse, ResponseCallback, SendData } from "../api/RestAPI";
 
 import { ConfigurationCreateParams, ConfigurationItem, ConfigurationUpdateParams } from "./common/Configuration";
 import { WithMerchantName } from "./common/types";
@@ -42,27 +42,46 @@ export class Stores extends CRUDResource {
 
     static routeBase = "/stores";
 
-    list(data?: SendData<StoresListParams>, callback?: ResponseCallback<ResponseStores>): Promise<ResponseStores> {
-        return this._listRoute()(data, callback);
+    list(
+        data?: SendData<StoresListParams>,
+        auth?: AuthParams,
+        callback?: ResponseCallback<ResponseStores>
+    ): Promise<ResponseStores> {
+        return this._listRoute()(data, callback, auth);
     }
 
-    create(data: SendData<StoreCreateParams>, callback?: ResponseCallback<ResponseStore>): Promise<ResponseStore> {
-        return this._createRoute(Stores.requiredParams)(data, callback);
+    create(
+        data: SendData<StoreCreateParams>,
+        auth?: AuthParams,
+        callback?: ResponseCallback<ResponseStore>
+    ): Promise<ResponseStore> {
+        return this._createRoute(Stores.requiredParams)(data, callback, auth);
     }
 
-    get(id: string, data?: SendData<void>, callback?: ResponseCallback<ResponseStore>): Promise<ResponseStore> {
-        return this._getRoute()(data, callback, ["id"], id);
+    get(
+        id: string,
+        data?: SendData<void>,
+        auth?: AuthParams,
+        callback?: ResponseCallback<ResponseStore>
+    ): Promise<ResponseStore> {
+        return this._getRoute()(data, callback, auth, { id });
     }
 
     update(
         id: string,
         data?: SendData<StoreUpdateParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseStore>
     ): Promise<ResponseStore> {
-        return this._updateRoute()(data, callback, ["id"], id);
+        return this._updateRoute()(data, callback, auth, { id });
     }
 
-    delete(id: string, data?: SendData<void>, callback?: ResponseCallback<ErrorResponse>): Promise<ErrorResponse> {
-        return this._deleteRoute()(data, callback, ["id"], id);
+    delete(
+        id: string,
+        data?: SendData<void>,
+        auth?: AuthParams,
+        callback?: ResponseCallback<ErrorResponse>
+    ): Promise<ErrorResponse> {
+        return this._deleteRoute()(data, callback, auth, { id });
     }
 }

--- a/src/resources/TemporaryTokenAlias.ts
+++ b/src/resources/TemporaryTokenAlias.ts
@@ -2,7 +2,7 @@
  *  @module Resources/TemporaryTokenAlias
  */
 
-import { ErrorResponse, HTTPMethod, ResponseCallback, SendData } from "../api/RestAPI";
+import { AuthParams, ErrorResponse, HTTPMethod, ResponseCallback, SendData } from "../api/RestAPI";
 
 import { ProcessingMode } from "./common/enums";
 import { Metadata } from "./common/types";
@@ -77,21 +77,28 @@ export class TemporaryTokenAlias extends CRUDResource {
 
     create(
         data: SendData<TemporaryTokenAliasCreateParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseTemporaryTokenAlias>
     ): Promise<ResponseTemporaryTokenAlias> {
-        return this.defineRoute(HTTPMethod.POST, "/tokens/alias", TemporaryTokenAlias.requiredParams)(data, callback);
+        return this.defineRoute(HTTPMethod.POST, "/tokens/alias", TemporaryTokenAlias.requiredParams)(
+            data,
+            callback,
+            auth
+        );
     }
 
     get(
         storeId: string,
         id: string,
         data?: SendData<TemporaryTokenAliasQrOptions>,
+        auth?: AuthParams,
         callback?: ResponseCallback<Blob>
     ): Promise<Blob>;
     get(
         storeId: string,
         id: string,
         data?: SendData<TemporaryTokenAliasParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseTemporaryTokenAlias>
     ): Promise<ResponseTemporaryTokenAlias>;
 
@@ -99,6 +106,7 @@ export class TemporaryTokenAlias extends CRUDResource {
         storeId: string,
         id: string,
         data?: SendData<TemporaryTokenAliasParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<any>
     ): Promise<any> {
         return this.defineRoute(
@@ -107,15 +115,16 @@ export class TemporaryTokenAlias extends CRUDResource {
             undefined,
             undefined,
             data && data.media === TemporaryTokenAliasMedia.QR ? "image/png" : undefined
-        )(data, callback, ["storeId", "id"], storeId, id);
+        )(data, callback, auth, { storeId, id });
     }
 
     delete(
         storeId: string,
         id: string,
         data?: SendData<void>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ErrorResponse>
     ): Promise<ErrorResponse> {
-        return this._deleteRoute()(data, callback, ["storeId", "id"], storeId, id);
+        return this._deleteRoute()(data, callback, auth, { storeId, id });
     }
 }

--- a/src/resources/TransactionTokens.ts
+++ b/src/resources/TransactionTokens.ts
@@ -2,7 +2,7 @@
  *  @module Resources/TransactionTokens
  */
 
-import { ErrorResponse, HTTPMethod, ResponseCallback, SendData } from "../api/RestAPI";
+import { AuthParams, ErrorResponse, HTTPMethod, ResponseCallback, SendData } from "../api/RestAPI";
 
 import {
     CardBrand,
@@ -202,58 +202,61 @@ export class TransactionTokens extends CRUDResource {
 
     create(
         data: SendData<TransactionTokenCreateParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseTransactionToken>
     ): Promise<ResponseTransactionToken> {
-        return this.defineRoute(HTTPMethod.POST, "/tokens", TransactionTokens.requiredParams)(data, callback);
+        return this.defineRoute(HTTPMethod.POST, "/tokens", TransactionTokens.requiredParams)(data, callback, auth);
     }
 
     get(
         storeId: string,
         id: string,
         data?: SendData<void>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseTransactionToken>
     ): Promise<ResponseTransactionToken> {
-        return this._getRoute()(data, callback, ["storeId", "id"], storeId, id);
+        return this._getRoute()(data, callback, auth, { storeId, id });
     }
 
     list(
         data?: SendData<TransactionTokenListParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseTransactionTokens>,
         storeId?: string
     ): Promise<ResponseTransactionTokens> {
-        return this.defineRoute(HTTPMethod.GET, "(/stores/:storeId)/tokens")(data, callback, ["storeId"], storeId);
+        return this.defineRoute(HTTPMethod.GET, "(/stores/:storeId)/tokens")(data, callback, auth, { storeId });
     }
 
     update(
         storeId: string,
         id: string,
         data?: SendData<TransactionTokenUpdateParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseTransactionToken>
     ): Promise<ResponseTransactionToken> {
-        return this._updateRoute()(data, callback, ["storeId", "id"], storeId, id);
+        return this._updateRoute()(data, callback, auth, { storeId, id });
     }
 
     delete(
         storeId: string,
         id: string,
         data?: SendData<void>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ErrorResponse>
     ): Promise<ErrorResponse> {
-        return this._deleteRoute()(data, callback, ["storeId", "id"], storeId, id);
+        return this._deleteRoute()(data, callback, auth, { storeId, id });
     }
 
     confirm(
         storeId: string,
         id: string,
         data: SendData<TransactionTokenConfirmParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ErrorResponse>
     ): Promise<ErrorResponse> {
-        return this.defineRoute(HTTPMethod.POST, "/stores/:storeId/tokens/:id/confirm")(
-            data,
-            callback,
-            ["storeId", "id"],
+        return this.defineRoute(HTTPMethod.POST, "/stores/:storeId/tokens/:id/confirm")(data, callback, auth, {
             storeId,
-            id
-        );
+            id,
+        });
     }
 }

--- a/src/resources/Transfers.ts
+++ b/src/resources/Transfers.ts
@@ -2,7 +2,7 @@
  *  @module Resources/Transfers
  */
 
-import { HTTPMethod, ResponseCallback, SendData } from "../api/RestAPI";
+import { AuthParams, HTTPMethod, ResponseCallback, SendData } from "../api/RestAPI";
 
 import { Metadata, WithMerchantName } from "./common/types";
 import { CRUDItemsResponse, CRUDPaginationParams, CRUDResource } from "./CRUDResource";
@@ -63,25 +63,29 @@ export class Transfers extends CRUDResource {
 
     list(
         data?: SendData<TransfersListParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseTransfers>
     ): Promise<ResponseTransfers> {
-        return this._listRoute()(data, callback);
+        return this._listRoute()(data, callback, auth);
     }
 
-    get(id: string, data?: SendData<void>, callback?: ResponseCallback<ResponseTransfer>): Promise<ResponseTransfer> {
-        return this._getRoute()(data, callback, ["id"], id);
+    get(
+        id: string,
+        data?: SendData<void>,
+        auth?: AuthParams,
+        callback?: ResponseCallback<ResponseTransfer>
+    ): Promise<ResponseTransfer> {
+        return this._getRoute()(data, callback, auth, { id });
     }
 
     statusChanges(
         id: string,
         data?: SendData<void>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseTransferStatusChanges>
     ): Promise<ResponseTransferStatusChanges> {
-        return this.defineRoute(HTTPMethod.GET, `${Transfers.routeBase}/:id/status_changes`)(
-            data,
-            callback,
-            ["id"],
-            id
-        );
+        return this.defineRoute(HTTPMethod.GET, `${Transfers.routeBase}/:id/status_changes`)(data, callback, auth, {
+            id,
+        });
     }
 }

--- a/src/resources/Verification.ts
+++ b/src/resources/Verification.ts
@@ -2,7 +2,7 @@
  *  @module Resources/Verification
  */
 
-import { HTTPMethod, ResponseCallback, SendData } from "../api/RestAPI";
+import { AuthParams, HTTPMethod, ResponseCallback, SendData } from "../api/RestAPI";
 
 import { ContactInfo, ContactInfoPartial } from "./common/ContactInfo";
 import { PhoneNumber } from "./common/types";
@@ -47,19 +47,25 @@ export class Verification extends CRUDResource {
 
     create(
         data: SendData<VerificationCreateParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseVerification>
     ): Promise<ResponseVerification> {
-        return this._createRoute(Verification.requiredParams)(data, callback);
+        return this._createRoute(Verification.requiredParams)(data, callback, auth);
     }
 
-    get(data?: SendData<void>, callback?: ResponseCallback<ResponseVerification>): Promise<ResponseVerification> {
-        return this.defineRoute(HTTPMethod.GET, this._routeBase)(data, callback);
+    get(
+        data?: SendData<void>,
+        auth?: AuthParams,
+        callback?: ResponseCallback<ResponseVerification>
+    ): Promise<ResponseVerification> {
+        return this.defineRoute(HTTPMethod.GET, this._routeBase)(data, callback, auth);
     }
 
     update(
         data?: SendData<VerificationUpdateParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseVerification>
     ): Promise<ResponseVerification> {
-        return this.defineRoute(HTTPMethod.PATCH, this._routeBase)(data, callback);
+        return this.defineRoute(HTTPMethod.PATCH, this._routeBase)(data, callback, auth);
     }
 }

--- a/src/resources/WebHooks.ts
+++ b/src/resources/WebHooks.ts
@@ -2,7 +2,7 @@
  *  @module Resources/WebHooks
  */
 
-import { ErrorResponse, ResponseCallback, SendData } from "../api/RestAPI";
+import { AuthParams, ErrorResponse, ResponseCallback, SendData } from "../api/RestAPI";
 
 import { WithStoreMerchantName } from "./common/types";
 import { CRUDItemsResponse, CRUDPaginationParams, CRUDResource } from "./CRUDResource";
@@ -59,44 +59,49 @@ export class WebHooks<TriggerType = WebHookTrigger> extends CRUDResource {
 
     list(
         data?: SendData<WebHooksListParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseWebHooks<TriggerType>>,
         storeId?: string
     ): Promise<ResponseWebHooks<TriggerType>> {
-        return this._listRoute()(data, callback, ["storeId"], storeId);
+        return this._listRoute()(data, callback, auth, { storeId });
     }
 
     create(
         data: SendData<WebHookCreateParams<TriggerType>>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseWebHook<TriggerType>>,
         storeId?: string
     ): Promise<ResponseWebHook<TriggerType>> {
-        return this._createRoute(WebHooks.requiredParams)(data, callback, ["storeId"], storeId);
+        return this._createRoute(WebHooks.requiredParams)(data, callback, auth, { storeId });
     }
 
     get(
         id: string,
         data?: SendData<void>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseWebHook<TriggerType>>,
         storeId?: string
     ): Promise<ResponseWebHook<TriggerType>> {
-        return this._getRoute()(data, callback, ["storeId", "id"], storeId, id);
+        return this._getRoute()(data, callback, auth, { storeId, id });
     }
 
     update(
         id: string,
         data?: SendData<WebHookUpdateParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseWebHook<TriggerType>>,
         storeId?: string
     ): Promise<ResponseWebHook<TriggerType>> {
-        return this._updateRoute()(data, callback, ["storeId", "id"], storeId, id);
+        return this._updateRoute()(data, callback, auth, { storeId, id });
     }
 
     delete(
         id: string,
         data?: SendData<void>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ErrorResponse>,
         storeId?: string
     ): Promise<ErrorResponse> {
-        return this._deleteRoute()(data, callback, ["storeId", "id"], storeId, id);
+        return this._deleteRoute()(data, callback, auth, { storeId, id });
     }
 }

--- a/test/specs/charges.specs.ts
+++ b/test/specs/charges.specs.ts
@@ -82,7 +82,7 @@ describe("Charges", () => {
                 headers: { "Content-Type": "application/json" },
             });
 
-            const asserts = [charges.list(null, null), charges.list(null, null, uuid())];
+            const asserts = [charges.list(null, null), charges.list(null, undefined, null, uuid())];
 
             for (const assert of asserts) {
                 await expect(assert).to.eventually.eql(listData);

--- a/test/specs/subscriptions.specs.ts
+++ b/test/specs/subscriptions.specs.ts
@@ -96,7 +96,7 @@ describe("Subscriptions", () => {
                 headers: { "Content-Type": "application/json" },
             });
 
-            const asserts = [subscriptions.list(null, null), subscriptions.list(null, null, uuid())];
+            const asserts = [subscriptions.list(null, null, null), subscriptions.list(null, null, null, uuid())];
 
             for (const assert of asserts) {
                 await expect(assert).to.eventually.eql(listData);
@@ -241,7 +241,7 @@ describe("Subscriptions", () => {
                 period: SubscriptionPeriod.MONTHLY,
             };
 
-            const asserts = [subscriptions.simulation(data), subscriptions.simulation(data, null, uuid())];
+            const asserts = [subscriptions.simulation(data), subscriptions.simulation(data, null, null, uuid())];
 
             for (const assert of asserts) {
                 await expect(assert).to.eventually.eql(simulationData);

--- a/test/specs/transaction-tokens.specs.ts
+++ b/test/specs/transaction-tokens.specs.ts
@@ -97,7 +97,7 @@ describe("Transaction Tokens", () => {
                 headers: { "Content-Type": "application/json" },
             });
 
-            const asserts = [transactionTokens.list(), transactionTokens.list(null, null, uuid())];
+            const asserts = [transactionTokens.list(), transactionTokens.list(null, null, null, uuid())];
 
             for (const assert of asserts) {
                 await expect(assert).to.eventually.eql(listData);

--- a/test/specs/webhooks.specs.ts
+++ b/test/specs/webhooks.specs.ts
@@ -41,7 +41,7 @@ describe("Web Hooks", () => {
                 url: "http://fake.com",
             };
 
-            const asserts = [webHooks.create(data), webHooks.create(data, null, uuid())];
+            const asserts = [webHooks.create(data), webHooks.create(data, null, null, uuid())];
 
             for (const assert of asserts) {
                 await expect(assert).to.eventually.eql(recordData);
@@ -76,7 +76,7 @@ describe("Web Hooks", () => {
                 headers: { "Content-Type": "application/json" },
             });
 
-            const asserts = [webHooks.list(), webHooks.list(null, null, uuid())];
+            const asserts = [webHooks.list(), webHooks.list(null, null, null, uuid())];
 
             for (const assert of asserts) {
                 await expect(assert).to.eventually.eql(listData);
@@ -92,7 +92,7 @@ describe("Web Hooks", () => {
                 headers: { "Content-Type": "application/json" },
             });
 
-            const asserts = [webHooks.get(uuid()), webHooks.get(uuid(), null, null, uuid())];
+            const asserts = [webHooks.get(uuid()), webHooks.get(uuid(), null, null, null, uuid())];
 
             for (const assert of asserts) {
                 await expect(assert).to.eventually.eql(recordData);
@@ -113,7 +113,7 @@ describe("Web Hooks", () => {
                 url: "http://fake.com",
             };
 
-            const asserts = [webHooks.update(uuid(), data), webHooks.update(uuid(), data, null, uuid())];
+            const asserts = [webHooks.update(uuid(), data), webHooks.update(uuid(), data, null, null, uuid())];
 
             for (const assert of asserts) {
                 await expect(assert).to.eventually.eql(recordData);
@@ -128,7 +128,7 @@ describe("Web Hooks", () => {
                 headers: { "Content-Type": "application/json" },
             });
 
-            const asserts = [webHooks.delete(uuid()), webHooks.delete(uuid(), null, null, uuid())];
+            const asserts = [webHooks.delete(uuid()), webHooks.delete(uuid(), null, null, null, uuid())];
 
             for (const assert of asserts) {
                 await expect(assert).to.eventually.be.empty;


### PR DESCRIPTION
Blocks https://github.com/univapaycast/services-typescript/issues/25

This is needed in the `miniapp` API to make requests to different `stores` with the same `SDK` object.
The implementation was, as usual, easier than anticipated.
On the `API` surface, this is only breaking if using the `callback` style API calls, since the `callback` argument in all resources moved one step back to make space for `auth` parameters.
Under the surface, I simplified the `pathParameters` mechanism and moved the parameter order slightly, but the tests all pass just the same!
The heart of this PR is in [this](https://github.com/univapay/univapay-node/blob/b9eaaf9c5f4a9b6ee9a34cb5636995cff1b049c7/src/api/RestAPI.ts#L303) line, where I will set the auth params passed directly into the method to the highest priority.