### PR TITLE
add auth param in BankAccounts for consistency

### DIFF
--- a/src/resources/BankAccounts.ts
+++ b/src/resources/BankAccounts.ts
@@ -73,9 +73,10 @@ export class BankAccounts extends CRUDResource {
 
     list(
         data?: SendData<BankAccountsListParams>,
+        auth?: AuthParams,
         callback?: ResponseCallback<ResponseBankAccounts>
     ): Promise<ResponseBankAccounts> {
-        return this._listRoute()(data, callback);
+        return this._listRoute()(data, callback, auth);
     }
 
     create(


### PR DESCRIPTION
No associated ticket

It seems this is the only endpoint that is missing `auth` param, i think we missed it.