### PR TITLE
issuerToken httpMethod is now callMethod

### DIFF
--- a/src/resources/Charges.ts
+++ b/src/resources/Charges.ts
@@ -66,7 +66,7 @@ export interface ChargeItem {
 
 export interface IssuerTokenItem {
     issuerToken: string;
-    httpMethod: string;
+    callMethod: string;
 }
 
 export type ChargeListItem = WithStoreMerchantName<ChargeItem>;

--- a/src/resources/Charges.ts
+++ b/src/resources/Charges.ts
@@ -66,7 +66,7 @@ export interface ChargeItem {
 
 export interface IssuerTokenItem {
     issuerToken: string;
-    callMethod: string;
+    callMethod: "http_get" | "http_post" | "sdk";
 }
 
 export type ChargeListItem = WithStoreMerchantName<ChargeItem>;

--- a/test/specs/charges.specs.ts
+++ b/test/specs/charges.specs.ts
@@ -155,7 +155,7 @@ describe("Charges", () => {
             const pathMatcher = pathToRegexMatcher(`${testEndpoint}/stores/:storeId/charges/:chargeId/issuerToken`);
             const recordIssuerToken = {
                 issuerToken: "mytoken",
-                httpMethod: "POST",
+                callMethod: "POST",
             };
             fetchMock.getOnce(pathMatcher, {
                 status: 200,

--- a/test/specs/charges.specs.ts
+++ b/test/specs/charges.specs.ts
@@ -155,7 +155,7 @@ describe("Charges", () => {
             const pathMatcher = pathToRegexMatcher(`${testEndpoint}/stores/:storeId/charges/:chargeId/issuerToken`);
             const recordIssuerToken = {
                 issuerToken: "mytoken",
-                callMethod: "POST",
+                callMethod: "http_get",
             };
             fetchMock.getOnce(pathMatcher, {
                 status: 200,


### PR DESCRIPTION
Apparently this is up on staging

Related issues:
https://github.com/univapaycast/services-typescript/issues/32
https://github.com/univapaycast/gyron-payments-api/commit/daaeed0be2e8a27642b1bc959b77e3cd32e9ac47