### PR TITLE
Enhance metadata typings

### DIFF
--- a/src/resources/Cancels.ts
+++ b/src/resources/Cancels.ts
@@ -18,18 +18,18 @@ export enum CancelStatus {
 /* Request */
 export type CancelsListParams = CRUDPaginationParams;
 
-export interface CancelCreateParams {
-    metadata?: Metadata;
+export interface CancelCreateParams<T extends Metadata = Metadata> {
+    metadata?: T;
 }
 
 /* Response */
-export interface CancelItem {
+export interface CancelItem<T extends Metadata = Metadata> {
     id: string;
     chargeId: string;
     storeId?: string;
     status: CancelStatus;
     error?: PaymentError;
-    metadata?: Metadata;
+    metadata?: T;
     mode: ProcessingMode;
     createdOn: string;
 }

--- a/src/resources/Charges.ts
+++ b/src/resources/Charges.ts
@@ -24,7 +24,7 @@ export enum ChargeStatus {
 /* Request */
 export type ChargesListParams = CRUDPaginationParams;
 
-export interface ChargeCreateParams {
+export interface ChargeCreateParams<T extends Metadata = Metadata> {
     transactionTokenId: string;
     amount: number;
     currency: string;
@@ -33,13 +33,13 @@ export interface ChargeCreateParams {
     descriptor?: string;
     ignoreDescriptorOnError?: boolean;
     onlyDirectCurrency?: boolean;
-    metadata?: Metadata;
+    metadata?: T;
 }
 
 export type ChargeIssuerTokenGetParams = void;
 
 /* Response */
-export interface ChargeItem {
+export interface ChargeItem<T extends Metadata = Metadata> {
     id: string;
     merchantId: string;
     storeId: string;
@@ -55,7 +55,7 @@ export interface ChargeItem {
     captureStatus?: CaptureStatus;
     status: ChargeStatus;
     error?: PaymentError;
-    metadata?: Metadata;
+    metadata?: T;
     mode: ProcessingMode;
     createdOn: string;
     transactionTokenId?: string;

--- a/src/resources/Refunds.ts
+++ b/src/resources/Refunds.ts
@@ -25,23 +25,23 @@ export enum RefundReason {
 /* Request */
 export type RefundsListParams = CRUDPaginationParams;
 
-export interface RefundCreateParams {
+export interface RefundCreateParams<T extends Metadata = Metadata> {
     amount: number;
     currency: string;
     reason?: RefundReason;
     message?: string;
-    metadata?: Metadata;
+    metadata?: T;
 }
 
-export interface RefundUpdateParams {
+export interface RefundUpdateParams<T extends Metadata = Metadata> {
     status?: RefundStatus;
     reason?: RefundReason;
     message?: string;
-    metadata?: Metadata;
+    metadata?: T;
 }
 
 /* Response */
-export interface RefundItem {
+export interface RefundItem<T extends Metadata = Metadata> {
     id: string;
     storeId: string;
     chargeId: string;
@@ -53,7 +53,7 @@ export interface RefundItem {
     reason?: RefundReason;
     message?: string;
     error?: PaymentError;
-    metadata?: Metadata;
+    metadata?: T;
     mode: ProcessingMode;
     createdOn: string;
 }

--- a/src/resources/Subscriptions.ts
+++ b/src/resources/Subscriptions.ts
@@ -80,13 +80,13 @@ export interface SubscriptionsListParams extends CRUDPaginationParams {
 
 export type ScheduledPaymentsListParams = CRUDPaginationParams;
 
-export interface SubscriptionCreateBaseParams {
+export interface SubscriptionCreateBaseParams<T extends Metadata = Metadata> {
     transactionTokenId: string;
     amount: number;
     currency: string;
     period: SubscriptionPeriod;
     descriptor?: string;
-    metadata?: Metadata;
+    metadata?: T;
     initialAmount?: number;
     installmentPlan?: InstallmentPlanItem<any>;
     onlyDirectCurrency?: boolean;
@@ -102,11 +102,11 @@ export interface SubscriptionCreateNewParams extends SubscriptionCreateBaseParam
 
 export type SubscriptionCreateParams = SubscriptionCreateLegacyParams | SubscriptionCreateNewParams;
 
-export interface SubscriptionUpdateParams {
+export interface SubscriptionUpdateParams<T extends Metadata = Metadata> {
     transactionTokenId?: string;
     amount?: number;
     status?: SubscriptionStatus;
-    metadata?: Metadata;
+    metadata?: T;
     installmentPlan?: Partial<InstallmentPlanItem<any>>;
     onlyDirectCurrency?: boolean;
 }
@@ -120,7 +120,7 @@ export interface ScheduleSettings {
 }
 
 /* Response */
-export interface SubscriptionItem {
+export interface SubscriptionItem<T extends Metadata = Metadata> {
     id: string;
     storeId: string;
     amount: number;
@@ -134,7 +134,7 @@ export interface SubscriptionItem {
     subsequentCyclesStart?: string;
     scheduleSettings: ScheduleSettings;
     status: SubscriptionStatus;
-    metadata?: Metadata;
+    metadata?: T;
     mode: ProcessingMode;
     createdOn: string;
     installmentPlan?: InstallmentPlanItem<any>;

--- a/src/resources/TransactionTokens.ts
+++ b/src/resources/TransactionTokens.ts
@@ -95,7 +95,7 @@ export interface TransactionTokenPaidyData {
     phoneNumber: PhoneNumber;
 }
 
-export interface TransactionTokenCreateParams {
+export interface TransactionTokenCreateParams<T extends Metadata = Metadata> {
     paymentType: PaymentType;
     type: TransactionTokenType;
     email?: string;
@@ -106,7 +106,7 @@ export interface TransactionTokenCreateParams {
         | TransactionTokenConvenienceData
         | TransactionTokenOnlineData
         | TransactionTokenPaidyData;
-    metadata?: Metadata;
+    metadata?: T;
     useConfirmation?: boolean;
 }
 
@@ -171,7 +171,7 @@ export interface TransactionTokenConvenienceDataItem {
     phoneNumber?: PhoneNumber;
 }
 
-export interface TransactionTokenItem {
+export interface TransactionTokenItem<T extends Metadata = Metadata> {
     id: string;
     storeId: string;
     email: string;
@@ -187,7 +187,7 @@ export interface TransactionTokenItem {
         | TransactionTokenConvenienceDataItem
         | TransactionTokenOnlineDataItem
         | TransactionTokenPaidyData;
-    metadata?: Metadata;
+    metadata?: T;
 }
 
 export type TransactionTokenListItem = WithStoreMerchantName<TransactionTokenItem>;

--- a/src/resources/Transfers.ts
+++ b/src/resources/Transfers.ts
@@ -25,7 +25,7 @@ export interface TransfersListParams extends CRUDPaginationParams {
 }
 
 /* Response */
-export interface TransferItem {
+export interface TransferItem<T extends Metadata = Metadata> {
     id: string;
     merchantId: string;
     bankAccountId: string;
@@ -35,7 +35,7 @@ export interface TransferItem {
     status: TransferStatus;
     errorCode?: string;
     errorText?: string;
-    metadata?: Metadata;
+    metadata?: T;
     startedBy: string;
     createdOn: string;
     from: string;

--- a/src/resources/WebHooks.ts
+++ b/src/resources/WebHooks.ts
@@ -2,7 +2,7 @@
  *  @module Resources/WebHooks
  */
 
-import { AuthParams, ErrorResponse, ResponseCallback, SendData } from "../api/RestAPI";
+import { AuthParams, ResponseCallback, SendData } from "../api/RestAPI";
 
 import { WithStoreMerchantName } from "./common/types";
 import { CRUDItemsResponse, CRUDPaginationParams, CRUDResource } from "./CRUDResource";
@@ -102,9 +102,9 @@ export class WebHooks<TriggerType = WebHookTrigger> extends CRUDResource {
         id: string,
         data?: SendData<void>,
         auth?: AuthParams,
-        callback?: ResponseCallback<ErrorResponse>,
+        callback?: ResponseCallback<void>,
         storeId?: string
-    ): Promise<ErrorResponse> {
+    ): Promise<void> {
         return this._deleteRoute()(data, callback, auth, { storeId, id });
     }
 }


### PR DESCRIPTION
Tiny typing enhancements that would be useful for me in the miniapp API.
The `ReturnType<Webhooks["delete"]>` type is corrected.
The `Metadata` type is made generic in case your application has a specific `Metadata` format