### PR TITLE
fix unhandled error type in serializeErrorResponse

### DIFF
--- a/src/errors/RequestResponseError.ts
+++ b/src/errors/RequestResponseError.ts
@@ -2,13 +2,17 @@
  *  @module Errors
  */
 
+import { isObject } from "lodash";
+
 import { ErrorResponse } from "../api/RestAPI";
 
 type ErrorRequest = Omit<ErrorResponse, "status">;
 
 const serializeErrorResponse = ({ code, httpCode, errors }: ErrorRequest): string =>
     `Code: ${code}, HttpCode: ${httpCode}, Errors: ${(errors || [])
-        .map((error) => ("field" in error ? `${error.reason} (${error.field})` : error.reason))
+        .map((error) =>
+            isObject(error) ? ("field" in error ? `${error.reason} (${error.field})` : error.reason) : error
+        )
         .join(", ")}`;
 
 export class RequestResponseBaseError extends Error {


### PR DESCRIPTION
No associated ticket.

Fixes/improves handling non-object error types returned from API (i.e. `string` types).