### PR TITLE
Allow overriding the key formatter

### DIFF
--- a/src/api/utils/payload.ts
+++ b/src/api/utils/payload.ts
@@ -26,7 +26,7 @@ export function containsBinaryData(data: any): boolean {
     return false;
 }
 
-export function objectToFormData(obj: any, rootName = "", ignoreList: string[] = null) {
+export function objectToFormData(obj: any, rootName = "", ignoreList: string[] = null, keyFormatter = decamelize) {
     const formData = new FormData();
 
     function isBlob(data: any): boolean {
@@ -48,7 +48,7 @@ export function objectToFormData(obj: any, rootName = "", ignoreList: string[] =
     function appendFormData(data: any, root = "") {
         if (!ignore(root)) {
             if (isBlob(data)) {
-                formData.append(decamelize(root), data);
+                formData.append(keyFormatter(root), data);
             } else if (Array.isArray(data)) {
                 for (let i = 0; i < data.length; i++) {
                     appendFormData(data[i], `${root}[${i}]`);
@@ -63,7 +63,7 @@ export function objectToFormData(obj: any, rootName = "", ignoreList: string[] =
                 }
             } else {
                 if (data !== null && typeof data !== "undefined") {
-                    formData.append(decamelize(root), data);
+                    formData.append(keyFormatter(root), data);
                 }
             }
         }

--- a/src/resources/CRUDResource.ts
+++ b/src/resources/CRUDResource.ts
@@ -36,23 +36,68 @@ export abstract class CRUDResource extends Resource {
         this._routeBase = (this.constructor as CRUDResourceStatic).routeBase;
     }
 
-    protected _listRoute(required?: string[]): DefinedRoute {
-        return this.defineRoute(HTTPMethod.GET, this._routeBase, required);
+    protected _listRoute(
+        required?: string[],
+        requireAuth?: boolean,
+        acceptType?: string,
+        keyFormatter?: (key: string) => string
+    ): DefinedRoute {
+        return this.defineRoute(HTTPMethod.GET, this._routeBase, required, requireAuth, acceptType, keyFormatter);
+    }
+    protected _createRoute(
+        required?: string[],
+        requireAuth?: boolean,
+        acceptType?: string,
+        keyFormatter?: (key: string) => string
+    ): DefinedRoute {
+        return this.defineRoute(HTTPMethod.POST, this._routeBase, required, requireAuth, acceptType, keyFormatter);
     }
 
-    protected _createRoute(required?: string[]): DefinedRoute {
-        return this.defineRoute(HTTPMethod.POST, this._routeBase, required);
+    protected _getRoute(
+        required?: string[],
+        requireAuth?: boolean,
+        acceptType?: string,
+        keyFormatter?: (key: string) => string
+    ): DefinedRoute {
+        return this.defineRoute(
+            HTTPMethod.GET,
+            `${this._routeBase}/:id`,
+            required,
+            requireAuth,
+            acceptType,
+            keyFormatter
+        );
     }
 
-    protected _getRoute(required?: string[]): DefinedRoute {
-        return this.defineRoute(HTTPMethod.GET, `${this._routeBase}/:id`, required);
+    protected _updateRoute(
+        required?: string[],
+        requireAuth?: boolean,
+        acceptType?: string,
+        keyFormatter?: (key: string) => string
+    ): DefinedRoute {
+        return this.defineRoute(
+            HTTPMethod.PATCH,
+            `${this._routeBase}/:id`,
+            required,
+            requireAuth,
+            acceptType,
+            keyFormatter
+        );
     }
 
-    protected _updateRoute(required?: string[]): DefinedRoute {
-        return this.defineRoute(HTTPMethod.PATCH, `${this._routeBase}/:id`, required);
-    }
-
-    protected _deleteRoute(required?: string[]): DefinedRoute {
-        return this.defineRoute(HTTPMethod.DELETE, `${this._routeBase}/:id`, required);
+    protected _deleteRoute(
+        required?: string[],
+        requireAuth?: boolean,
+        acceptType?: string,
+        keyFormatter?: (key: string) => string
+    ): DefinedRoute {
+        return this.defineRoute(
+            HTTPMethod.DELETE,
+            `${this._routeBase}/:id`,
+            required,
+            requireAuth,
+            acceptType,
+            keyFormatter
+        );
     }
 }

--- a/src/resources/Resource.ts
+++ b/src/resources/Resource.ts
@@ -2,6 +2,7 @@
  *  @internal
  *  @module Resources
  */
+import decamelize from "decamelize";
 import { EventEmitter } from "events";
 
 import { AuthParams, HTTPMethod, ResponseCallback, RestAPI, SendData } from "../api/RestAPI";
@@ -70,7 +71,8 @@ export abstract class Resource extends EventEmitter {
         path: string,
         required: string[] = [],
         requireAuth = true,
-        acceptType?: string
+        acceptType?: string,
+        keyFormatter = decamelize
     ): DefinedRoute {
         const api: RestAPI = this.api;
 
@@ -98,7 +100,7 @@ export abstract class Resource extends EventEmitter {
                 return Promise.reject(err);
             }
 
-            return api.send(method, url, data, auth, callback, requireAuth, acceptType);
+            return api.send(method, url, data, auth, callback, requireAuth, acceptType, keyFormatter);
         };
     }
 }

--- a/test/specs/payload.specs.ts
+++ b/test/specs/payload.specs.ts
@@ -105,4 +105,25 @@ describe("Payload Helpers", () => {
             .containingAllOf(["foo", "foo1.bar", "foo2[0]", "foo3[0].bar", "foo4", "foo_bar.fizz_buzz"])
             .and.not.containingAnyOf(["foo5", "foo6.bar"]);
     });
+
+    it("should create FormData object from raw data object with a specific key formatter", () => {
+        const obj = {
+            foo: "bar",
+            foo2: ["bar"],
+            fooBar: {
+                fizzBuzz: "test",
+            },
+        };
+
+        const formData = objectToFormData(obj, undefined, undefined, (key) => key);
+
+        expect(formData).to.be.instanceOf(FormData);
+
+        // This will only work in nodeJs environment
+        const names = arrayChunk((formData as any)._streams, 3).map(
+            ([name]: string[]) => name.match(/name="(.*)"/i)[1]
+        );
+
+        expect(names).to.be.array().which.deep.equals(["foo", "foo2[0]", "fooBar.fizzBuzz"]);
+    });
 });


### PR DESCRIPTION
Updates https://github.com/univapaycast/univapay-form-checkout/issues/51

The form checkout routes are accepting `camelCase` instead of `snake_case`. Ensure we can support both in the public SDK for the time being.