### PR TITLE
Fix/pierreh/fix nested ignored keys

### DIFF
--- a/src/api/RestAPI.ts
+++ b/src/api/RestAPI.ts
@@ -101,8 +101,8 @@ export type SendData<Data> = Data;
 
 function getRequestBody<Data>(data: SendData<Data>, keyFormatter = toSnakeCase): string | FormData {
     return containsBinaryData(data)
-        ? objectToFormData(data, keyFormatter)
-        : JSON.stringify(transformKeys(data, keyFormatter));
+        ? objectToFormData(data, keyFormatter, ["metadata"])
+        : JSON.stringify(transformKeys(data, keyFormatter, ["metadata"]));
 }
 
 function stringifyParams<Data extends Record<string, any>>(data: Data): string {

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -19,7 +19,7 @@ export const transformKeys = (
     const isObject = (value: unknown): value is Record<string, any> => typeof value === "object" && Boolean(value);
 
     const transformArray = (arr: unknown[], transformer: Transformer): any =>
-        arr.map((item) => (isObject(item) ? transformKeys(item, transformer) : item));
+        arr.map((item) => (isObject(item) ? transformKeys(item, transformer, ignoreKeys) : item));
 
     if (Array.isArray(obj)) {
         return transformArray(obj, transformer);
@@ -33,7 +33,7 @@ export const transformKeys = (
             return { ...acc, [key]: value };
         }
 
-        const formattedValue = isObject(value) ? transformKeys(value, transformer) : value;
+        const formattedValue = isObject(value) ? transformKeys(value, transformer, ignoreKeys) : value;
         acc[transformer(key)] = formattedValue;
         return acc;
     }, {});

--- a/test/specs/object.specs.ts
+++ b/test/specs/object.specs.ts
@@ -21,10 +21,11 @@ describe("Object Helpers", () => {
                 },
             ],
             myKey3: ["Value 5-1", "Value 5-2"],
-            myIgnoredKey1: { myIgnoredKey11: "Ignored value 1", "my-ignored-key=12": "Ignored value 2" },
+            myIgnoredKey1: { myIgnoredKey11: "Ignored value 11", "my-ignored-key=12": "Ignored value 12" },
+            myKey4: { myIgnoredKey2: "Ignored value 21" },
         };
 
-        const formattedData = transformKeys(data, toSnakeCase, ["myIgnoredKey1"]);
+        const formattedData = transformKeys(data, toSnakeCase, ["myIgnoredKey1", "myIgnoredKey2"]);
 
         expect(formattedData).eql({
             key1: "Value 1",
@@ -44,8 +45,11 @@ describe("Object Helpers", () => {
             ],
             my_key3: ["Value 5-1", "Value 5-2"],
             myIgnoredKey1: {
-                myIgnoredKey11: "Ignored value 1",
-                "my-ignored-key=12": "Ignored value 2",
+                myIgnoredKey11: "Ignored value 11",
+                "my-ignored-key=12": "Ignored value 12",
+            },
+            my_key4: {
+                myIgnoredKey2: "Ignored value 21",
             },
         });
     });


### PR DESCRIPTION
Fix for an issue caused by the changes for the IE/Edge compatibility

The code was relying heavily on the fact that the old library was only changing the `camelCase`, ignoring that metadata can have keys formatted in camelCase as well.

The PR changes three things:
- Use `transformKeys` in the `objectToFormData` function as they are supposed to be the same formatting
- Fix nested ignoredKeys in `transformKeys`
- Add the `metadata` to the ingoredKeys for the `getRequestBody` function as it needed here as well