### PR TITLE
Restrict published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
       "default": "./dist/esm/"
     }
   },
+  "files": [
+    "dist"
+  ],
   "jsnext:main": "dist/esm",
   "keywords": [
     "sdk",


### PR DESCRIPTION
Just noticed that `npm publish` will basically publish the whole module - usually we just need the md files and the `dist` directory published - `README.md` and `LICENSE` are always included by default. Maybe we could add `src` to the list, but not really necessary