### PR TITLE
Replace isomorphic-fetch with cross-fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1530,6 +1530,14 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "cross-fetch": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
+      "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+      "requires": {
+        "node-fetch": "2.6.1"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3119,15 +3127,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
-    },
-    "isomorphic-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-      "requires": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
-      }
     },
     "isomorphic-form-data": {
       "version": "2.0.0",
@@ -6223,11 +6222,6 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "dev": true
-    },
-    "whatwg-fetch": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
-      "integrity": "sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A=="
     },
     "whatwg-url": {
       "version": "6.5.0",

--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
   },
   "dependencies": {
     "change-case": "^4.1.2",
+    "cross-fetch": "^3.0.6",
     "events": "^3.2.0",
-    "isomorphic-fetch": "^3.0.0",
     "isomorphic-form-data": "^2.0.0",
     "jsonwebtoken": "^8.5.1",
     "query-string": "^5.1.1",

--- a/src/api/RestAPI.ts
+++ b/src/api/RestAPI.ts
@@ -5,7 +5,7 @@
 import { EventEmitter } from "events";
 import { stringify as stringifyQuery } from "query-string";
 
-import "isomorphic-fetch";
+import "cross-fetch/polyfill";
 import "isomorphic-form-data";
 
 import {

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -4,7 +4,7 @@ import chaiAsPromised from "chai-as-promised";
 import fetchMock from "fetch-mock";
 import sinonChai from "sinon-chai";
 
-import "isomorphic-fetch";
+import "cross-fetch/polyfill";
 
 /* Chai plugins */
 chai.use(chaiAsPromised);


### PR DESCRIPTION
This thing drove me crazy lol
Working on updates to the miniapp api, I noticed that requests to gpp stopped working with newer `univapay-node` versions.
After lots of digging, found that the cause was the upgrade to `isomorphic-fetch` [here](https://github.com/univapay/univapay-node/commit/0b78e088fbe0892f260b474dd6e6f49f10701fae).
`isomorphic-fetch@3` uses `node-fetch@2`, which introduced an `esm` module. When bundling with rollup, it would import `node-fetch` as a namespace, but `isomorphic-fetch` treated it as a cjs import. Long story short, everything beaks.
There is a fix pending in `isomorphic-fetch` https://github.com/matthew-andrews/isomorphic-fetch/pull/195, but doesn't seem like it'll be merged soon. On the other hand, `cross-fetch` already has the fix merged in and seems better maintained...