### PR TITLE
Correct package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
       "require": "./dist/cjs/index.js",
       "default": "./dist/esm/index.js"
     },
-    "./": {
-      "require": "./dist/cjs/",
-      "default": "./dist/esm/"
+    "./*": {
+      "require": "./dist/cjs/*.js",
+      "default": "./dist/esm/*.js"
     }
   },
   "files": [


### PR DESCRIPTION
Didn't notice subpath folders were deprecated in favor of subpath patterns:
https://nodejs.org/api/packages.html#packages_subpath_folder_mappings