### PR TITLE
Add gateway simulation errors as valid codes

### DIFF
--- a/src/errors/APIError.ts
+++ b/src/errors/APIError.ts
@@ -219,6 +219,15 @@ export enum ResponseErrorCode {
 
     /* Gateway simulation */
     PlatformCredentialsDisabled = "PLATFORM_CREDENTIALS_DISABLED",
+    ForbiddenGateway = "FORBIDDEN_GATEWAY",
+    ForbiddenQrGateway = "FORBIDDEN_QR_GATEWAY",
+    BlacklistedTagOnMerchant = "BLACKLISTED_TAG_ON_MERCHANT",
+    BlacklistedTagOnStore = "BLACKLISTED_TAG_ON_STORE",
+    NotOnWhitelist = "NOT_ON_WHITELIST",
+    CannotShareMerchantCredentials = "CANNOT_SHARE_MERCHANT_CREDENTIALS",
+    MissingGatewayConfiguration = "MISSING_GATEWAY_CONFIGURATION",
+    GatewayConfigNotFound = "GATEWAY_CONFIG_NOT_FOUND",
+    NotActive = "NOT_ACTIVE",
 
     /* Refund */
     RefundExceedsChargeAmount = "REFUND_EXCEEDS_CHARGE_AMOUNT",


### PR DESCRIPTION
Updates https://github.com/univapaycast/univapay-admin-console/issues/1146

This adds all the gateway simulation errors as valid ReponseError codes. I will be removing the admin console enum and rely on this function and type instead.

Context: To ensure type consistency the error formatting shows `UNKNOWN_ERROR` in case the error code is missing. 