### PR TITLE
Update error codes

### DIFF
--- a/src/errors/APIError.ts
+++ b/src/errors/APIError.ts
@@ -106,6 +106,8 @@ export enum ResponseErrorCode {
     AlreadyCaptured = "ALREADY_CAPTURED",
     CaptureAmountTooLarge = "CAPTURE_AMOUNT_TOO_LARGE",
     PartialCaptureNotSupported = "PARTIAL_CAPTURE_NOT_SUPPORTED",
+    DebitAuthorizationDisabled = "DEBIT_AUTHORIZATION_DISABLED",
+    PrePaidAuthorizationDisabled = "PREPAID_AUTHORIZATION_DISABLED",
 
     NoGatewaysAvailable = "NO_GATEWAY_AVAILABLE",
     CardBrandNotSupported = "CARD_BRAND_NOT_SUPPORTED",
@@ -170,7 +172,7 @@ export enum ResponseErrorCode {
     UnsupportedLanguage = "UNSUPPORTED_LANGUAGE",
     DefaultLanguageNotSupported = "DEFAULT_LANGUAGE_NOT_SUPPORTED",
     CaptureOnlyForCardPayment = "CAPTURE_ONLY_FOR_CARD_PAYMENT",
-    CaptureOnlyForCreditCards = "CAPTURE_ONLY_FOR_CREDIT_CARDS",
+    InvalidCardTypeForCapture = "INVALID_CARD_TYPE_FOR_CAPTURE",
     InvalidScheduledCaptureDate = "INVALID_SCHEDULED_CAPTURE_DATE",
     InvalidMerchantStatus = "INVALID_MERCHANT_STATUS",
     IncoherentDateRange = "INCOHERENT_DATE_RANGE",


### PR DESCRIPTION
Linked to the API error update:

```
起こり得る問題:
- エラーの詳細な理由の変更
  - 変更：「CAPTURE_ONLY_FOR_CREDIT_CARDS」から「INVALID_CARD_TYPE_FOR_CAPTURE」
  - オーソリする時に入力したカード番号のBIN詳細にカードタイプが不明な場合
  - 追加：「DEBIT_AUTHORIZATION_DISABLED」
  - オーソリする時に入力したカード番号のBIN詳細にカードタイプがデビットと「デビットオーソリ」設定が無効の場合
  - 追加：「PREPAID_AUTHORIZATION_DISABLED」
  - オーソリする時に入力したカード番号のBIN詳細にカードタイプがプリペイドと「プリペイドオーソリ」設定が無効の場合
```