### PR TITLE
Update husky recommendation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1613,12 +1613,6 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
-    "detect-indent": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
-      "integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==",
-      "dev": true
-    },
     "diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -2535,9 +2529,9 @@
       "dev": true
     },
     "husky": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-5.0.9.tgz",
-      "integrity": "sha512-0SjcaY21a+IRdx7p7r/X33Vc09UR2m8SbP8yfkhUX2/jAmwcz+GR7i9jXkp2pP3GfX23JhMkVP6SWwXB18uXtg==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-5.1.3.tgz",
+      "integrity": "sha512-fbNJ+Gz5wx2LIBtMweJNY1D7Uc8p1XERi5KNRMccwfQA+rXlxWNSdUxswo0gT8XqxywTIw7Ywm/F4v/O35RdMg==",
       "dev": true
     },
     "iconv-lite": {
@@ -5137,16 +5131,6 @@
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
     },
-    "pinst": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/pinst/-/pinst-2.1.4.tgz",
-      "integrity": "sha512-T44k87is/GiSjONFxSl/uL6yGqwVpojdnUfbYzNeatDTM8uRCoCEQjuQ0g1oW6XENfbdO2XKtMfdGlDSQ19MJA==",
-      "dev": true,
-      "requires": {
-        "fromentries": "^1.3.2",
-        "write-json-file": "^4.3.0"
-      }
-    },
     "pkg-dir": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
@@ -5871,23 +5855,6 @@
       "requires": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
-      }
-    },
-    "sort-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-4.2.0.tgz",
-      "integrity": "sha512-aUYIEU/UviqPgc8mHR6IW1EGxkAXpeRETYcrzg8cLAvUPZcpAlleSXHV2mY7G12GphSH6Gzv+4MMVSSkbdteHg==",
-      "dev": true,
-      "requires": {
-        "is-plain-obj": "^2.0.0"
-      },
-      "dependencies": {
-        "is-plain-obj": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-          "dev": true
-        }
       }
     },
     "source-map": {
@@ -6638,28 +6605,6 @@
         "is-typedarray": "^1.0.0",
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
-      }
-    },
-    "write-json-file": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-4.3.0.tgz",
-      "integrity": "sha512-PxiShnxf0IlnQuMYOPPhPkhExoCQuTUNPOa/2JWCYTmBquU9njyyDuwRKN26IZBlp4yn1nt+Agh2HOOBl+55HQ==",
-      "dev": true,
-      "requires": {
-        "detect-indent": "^6.0.0",
-        "graceful-fs": "^4.1.15",
-        "is-plain-obj": "^2.0.0",
-        "make-dir": "^3.0.0",
-        "sort-keys": "^4.0.0",
-        "write-file-atomic": "^3.0.0"
-      },
-      "dependencies": {
-        "is-plain-obj": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-          "dev": true
-        }
       }
     },
     "xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "eslint-plugin-prettier": "3.3.1",
     "eslint-plugin-simple-import-sort": "7.0.0",
     "fetch-mock": "9.11.0",
-    "husky": "^5.0.9",
+    "husky": "^5.1.3",
     "isomorphic-form-data": "^2.0.0",
     "lint-staged": "^10.5.4",
     "mocha": "8.3.0",
@@ -65,7 +65,6 @@
     "np": "7.4.0",
     "nyc": "15.1.0",
     "path-to-regexp": "6.2.0",
-    "pinst": "^2.1.4",
     "prettier": "2.2.1",
     "pretty-quick": "^3.1.0",
     "sinon": "9.2.4",
@@ -95,8 +94,6 @@
     "docs": "typedoc --options typedoc.json",
     "copy": "cp -rf package.json CHANGELOG.md LICENSE README.md dist",
     "release": "np --no-yarn --no-publish --no-release-draft",
-    "postinstall": "husky install",
-    "prepublishOnly": "pinst --disable",
-    "postpublish": "pinst --enable"
+    "prepare": "husky install"
   }
 }


### PR DESCRIPTION
Husky updated their recommendation for installation and this one is simpler and doesn't use `pinst`
https://github.com/typicode/husky/pull/890
