### PR TITLE
Add missing card categories

### DIFF
--- a/src/resources/common/enums.ts
+++ b/src/resources/common/enums.ts
@@ -35,6 +35,14 @@ export enum CardCategory {
     CLASSIC = "classic",
     CORPORATE = "corporate",
     PREPAID = "prepaid",
+    GOLD = "gold",
+    TITANIUM = "titanium",
+    PLATINUM = "platinum",
+    ATM = "atm",
+    ELECTRON = "electron",
+    MAESTRO = "maestro",
+    WORLD = "world",
+    BUSINESS ="business",
 }
 
 export enum ProcessingMode {


### PR DESCRIPTION
Linked to the old admin console charge transaction token crash: https://github.com/univapaycast/gyron-payments-admin-console/pull/2212

Adding the missing card category to fix the display on the new admin console.