### PR TITLE
Remove merchant id from ec-form public route

### DIFF
--- a/src/resources/ECFormLinks.ts
+++ b/src/resources/ECFormLinks.ts
@@ -21,15 +21,14 @@ export type ECFormLinkItem = {
 export type ResponseECFormLink = ECFormLinkItem;
 
 export class ECFormLinks extends CRUDResource {
-    static routeBase = "/merchants/:merchantId/checkout/links";
+    static routeBase = "/checkout/links";
 
     get(
-        merchantId: string,
         id: string,
         data?: SendData<void>,
         auth?: AuthParams,
         callback?: ResponseCallback<ResponseECFormLink>
     ): Promise<ResponseECFormLink> {
-        return this._getRoute()(data, callback, auth, { merchantId, id });
+        return this._getRoute()(data, callback, auth, { id });
     }
 }

--- a/src/resources/ECForms.ts
+++ b/src/resources/ECForms.ts
@@ -112,7 +112,7 @@ export type ResponseECForm<Metadata = BaseMetadata> = ECFormItem<Metadata>;
 
 export class ECForms extends CRUDResource {
     static requiredParams: string[] = [];
-    static routeBase = "checkout/forms";
+    static routeBase = "/checkout/forms";
 
     get(
         id: string,

--- a/src/resources/ECForms.ts
+++ b/src/resources/ECForms.ts
@@ -112,15 +112,14 @@ export type ResponseECForm<Metadata = BaseMetadata> = ECFormItem<Metadata>;
 
 export class ECForms extends CRUDResource {
     static requiredParams: string[] = [];
-    static routeBase = "/merchants/:merchantId/checkout/forms";
+    static routeBase = "checkout/forms";
 
     get(
-        merchantId: string,
         id: string,
         data?: SendData<void>,
         auth?: AuthParams,
         callback?: ResponseCallback<ECFormItem>
     ): Promise<ResponseECForm> {
-        return this._getRoute()(data, callback, auth, { merchantId, id });
+        return this._getRoute()(data, callback, auth, { id });
     }
 }

--- a/src/resources/Emails.ts
+++ b/src/resources/Emails.ts
@@ -21,15 +21,14 @@ export type EmailItem = {
 export type ResponseEmail = EmailItem;
 
 export class Emails extends CRUDResource {
-    static routeBase = "/merchants/:merchantId/checkout/emails";
+    static routeBase = "/checkout/emails";
 
     get(
-        merchantId: string,
         id: string,
         data?: SendData<void>,
         auth?: AuthParams,
         callback?: ResponseCallback<ResponseEmail>
     ): Promise<ResponseEmail> {
-        return this._getRoute()(data, callback, auth, { merchantId, id });
+        return this._getRoute()(data, callback, auth, { id });
     }
 }

--- a/test/specs/ec-form-links.specs.ts
+++ b/test/specs/ec-form-links.specs.ts
@@ -13,7 +13,7 @@ describe("EC Form links", () => {
     let ecFormLinks: ECFormLinks;
 
     const recordData = generateCheckoutInfo();
-    const recordPathMatcher = pathToRegexMatcher(`${testEndpoint}/merchants/:merchantId/checkout/links/:id`);
+    const recordPathMatcher = pathToRegexMatcher(`${testEndpoint}/checkout/links/:id`);
 
     beforeEach(() => {
         api = new RestAPI({ endpoint: testEndpoint });
@@ -24,7 +24,7 @@ describe("EC Form links", () => {
         fetchMock.restore();
     });
 
-    context("GET /merchants/:merchantId/checkout/links/:id", () => {
+    context("GET /checkout/links/:id", () => {
         it("should get response", async () => {
             fetchMock.getOnce(recordPathMatcher, {
                 status: 200,
@@ -32,7 +32,7 @@ describe("EC Form links", () => {
                 headers: { "Content-Type": "application/json" },
             });
 
-            await expect(ecFormLinks.get(uuid(), uuid())).to.eventually.eql(recordData);
+            await expect(ecFormLinks.get(uuid())).to.eventually.eql(recordData);
         });
     });
 });

--- a/test/specs/ec-forms.specs.ts
+++ b/test/specs/ec-forms.specs.ts
@@ -13,7 +13,7 @@ describe("EC Forms", () => {
     let ecForms: ECForms;
 
     const recordData = generateCheckoutInfo();
-    const recordPathMatcher = pathToRegexMatcher(`${testEndpoint}/merchants/:merchantId/checkout/forms/:id`);
+    const recordPathMatcher = pathToRegexMatcher(`${testEndpoint}/checkout/forms/:id`);
 
     beforeEach(() => {
         api = new RestAPI({ endpoint: testEndpoint });
@@ -24,7 +24,7 @@ describe("EC Forms", () => {
         fetchMock.restore();
     });
 
-    context("GET /merchants/:merchantId/checkout/forms/:id", () => {
+    context("GET /checkout/forms/:id", () => {
         it("should get response", async () => {
             fetchMock.getOnce(recordPathMatcher, {
                 status: 200,
@@ -32,7 +32,7 @@ describe("EC Forms", () => {
                 headers: { "Content-Type": "application/json" },
             });
 
-            await expect(ecForms.get(uuid(), uuid())).to.eventually.eql(recordData);
+            await expect(ecForms.get(uuid())).to.eventually.eql(recordData);
         });
     });
 });

--- a/test/specs/emails.specs.ts
+++ b/test/specs/emails.specs.ts
@@ -13,7 +13,7 @@ describe("Emails", () => {
     let emails: Emails;
 
     const recordData = generateCheckoutInfo();
-    const recordPathMatcher = pathToRegexMatcher(`${testEndpoint}/merchants/:merchantId/checkout/emails/:id`);
+    const recordPathMatcher = pathToRegexMatcher(`${testEndpoint}/checkout/emails/:id`);
 
     beforeEach(() => {
         api = new RestAPI({ endpoint: testEndpoint });
@@ -24,7 +24,7 @@ describe("Emails", () => {
         fetchMock.restore();
     });
 
-    context("GET /merchants/:merchantId/checkout/emails/:id", () => {
+    context("GET /checkout/emails/:id", () => {
         it("should get response", async () => {
             fetchMock.getOnce(recordPathMatcher, {
                 status: 200,
@@ -32,7 +32,7 @@ describe("Emails", () => {
                 headers: { "Content-Type": "application/json" },
             });
 
-            await expect(emails.get(uuid(), uuid())).to.eventually.eql(recordData);
+            await expect(emails.get(uuid())).to.eventually.eql(recordData);
         });
     });
 });


### PR DESCRIPTION
As we want to keep the route with the merchant for the merchant console in case we need to add extra parameters, we want the public SDK to not rely on the merchant id.

For historical reason the merchant id was added here but will most likely not be needed any longer due to the SSO changes (the ec-form lambda does not rely on this merchant id for validation any longer)