### PR TITLE
Enable node esm imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 node_modules/
-dist/
 docs/
+dist/*
+!dist/cjs
+dist/cjs/*
+!dist/cjs/package.json
 
 .DS_Store
 *.swp

--- a/dist/cjs/package.json
+++ b/dist/cjs/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "node": "^10 || ^12 || ^14"
   },
   "sideEffects": false,
+  "type": "module",
   "main": "dist/cjs",
   "module": "dist/esm",
   "exports": {


### PR DESCRIPTION
Recently have been trying to get `services-typescript` to load as an esm module to be able to upgrade some dependencies.
Turns out `univapay-node` still wasn't ready haha
This here should fix it