### PR TITLE
Build esm with extensions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,9 +53,11 @@
                 "sinon": "11.1.1",
                 "sinon-chai": "3.7.0",
                 "ts-node": "9.1.1",
+                "ttypescript": "^1.5.12",
                 "typedoc": "0.21.2",
                 "typedoc-plugin-internal-external": "2.2.0",
                 "typescript": "4.3.4",
+                "typescript-transform-extensions": "^1.0.1",
                 "uuid": "8.3.2"
             },
             "engines": {
@@ -8403,6 +8405,23 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
             "dev": true
         },
+        "node_modules/ttypescript": {
+            "version": "1.5.12",
+            "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
+            "integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
+            "dev": true,
+            "dependencies": {
+                "resolve": ">=1.9.0"
+            },
+            "bin": {
+                "ttsc": "bin/tsc",
+                "ttsserver": "bin/tsserver"
+            },
+            "peerDependencies": {
+                "ts-node": ">=8.0.2",
+                "typescript": ">=3.2.2"
+            }
+        },
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -8519,6 +8538,12 @@
             "engines": {
                 "node": ">=4.2.0"
             }
+        },
+        "node_modules/typescript-transform-extensions": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/typescript-transform-extensions/-/typescript-transform-extensions-1.0.1.tgz",
+            "integrity": "sha512-kV+h7R2Uenc6Jb/JDkKh8owJuW/LcaUg0cJQMTeJzvFdSiPOpfJhFkjEKAnTcRKYnHWSW+QOUcu5RnBFR8W5lQ==",
+            "dev": true
         },
         "node_modules/uglify-js": {
             "version": "3.13.10",
@@ -15379,6 +15404,15 @@
                 }
             }
         },
+        "ttypescript": {
+            "version": "1.5.12",
+            "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
+            "integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
+            "dev": true,
+            "requires": {
+                "resolve": ">=1.9.0"
+            }
+        },
         "tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -15458,6 +15492,12 @@
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
             "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
+            "dev": true
+        },
+        "typescript-transform-extensions": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/typescript-transform-extensions/-/typescript-transform-extensions-1.0.1.tgz",
+            "integrity": "sha512-kV+h7R2Uenc6Jb/JDkKh8owJuW/LcaUg0cJQMTeJzvFdSiPOpfJhFkjEKAnTcRKYnHWSW+QOUcu5RnBFR8W5lQ==",
             "dev": true
         },
         "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -72,11 +72,11 @@
         "sinon": "11.1.1",
         "sinon-chai": "3.7.0",
         "ts-node": "9.1.1",
-        "ttypescript": "^1.5.12",
+        "ttypescript": "1.5.12",
         "typedoc": "0.21.2",
         "typedoc-plugin-internal-external": "2.2.0",
         "typescript": "4.3.4",
-        "typescript-transform-extensions": "^1.0.1",
+        "typescript-transform-extensions": "1.0.1",
         "uuid": "8.3.2"
     },
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -72,9 +72,11 @@
         "sinon": "11.1.1",
         "sinon-chai": "3.7.0",
         "ts-node": "9.1.1",
+        "ttypescript": "^1.5.12",
         "typedoc": "0.21.2",
         "typedoc-plugin-internal-external": "2.2.0",
         "typescript": "4.3.4",
+        "typescript-transform-extensions": "^1.0.1",
         "uuid": "8.3.2"
     },
     "dependencies": {
@@ -91,7 +93,7 @@
         "test": "nyc mocha",
         "coverage": "nyc report --reporter=text-lcov | coveralls",
         "build:cjs": "tsc",
-        "build:esm": "tsc --project tsconfig.esm.json",
+        "build:esm": "ttsc --project tsconfig.esm.json",
         "build": "npm run build:cjs && npm run build:esm",
         "preversion": "npm test",
         "docs": "typedoc --options typedoc.json",

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -2,6 +2,12 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "es2015",
-    "outDir": "./dist/esm"
+    "outDir": "./dist/esm",
+    "plugins": [
+      {
+        "transform": "typescript-transform-extensions",
+        "extensions": {".ts": ".js"}
+      }
+    ]
   }
 }


### PR DESCRIPTION
After patching the consoles (which may be useful in some cases), here is the sdk fix to add the extensions to esm. That should make it backward compatible 🙂 