### PR TITLE
add interval for long poll

### DIFF
--- a/src/api/RestAPI.ts
+++ b/src/api/RestAPI.ts
@@ -314,12 +314,8 @@ export class RestAPI extends EventEmitter {
                 }),
                 // Repeater
                 (async function repeater(): Promise<A> {
-                    const result = await new Promise<A>((resolve) => {
-                        setTimeout(async () => {
-                            const r = await promise();
-                            resolve(r);
-                        }, interval);
-                    });
+                    await new Promise((resolve) => setTimeout(resolve, interval)); // sleep to avoid firing requests too fast
+                    const result = await promise();
 
                     if (cancelCondition && cancelCondition(result)) {
                         return null;

--- a/src/api/RestAPI.ts
+++ b/src/api/RestAPI.ts
@@ -314,7 +314,6 @@ export class RestAPI extends EventEmitter {
                 }),
                 // Repeater
                 (async function repeater(): Promise<A> {
-                    await new Promise((resolve) => setTimeout(resolve, interval)); // sleep to avoid firing requests too fast
                     const result = await promise();
 
                     if (cancelCondition && cancelCondition(result)) {
@@ -322,6 +321,7 @@ export class RestAPI extends EventEmitter {
                     }
 
                     if (!timedOut && !condition(result)) {
+                        await new Promise((resolve) => setTimeout(resolve, interval)); // sleep to avoid firing requests too fast
                         return repeater();
                     }
 

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -9,4 +9,5 @@ export const ENV_KEY_APP_ID = "UNIVAPAY_APP_ID";
 export const ENV_KEY_APPLICATION_JWT = "UNIVAPAY_APPLICATION_JWT";
 export const ENV_KEY_SECRET = "UNIVAPAY_SECRET";
 export const POLLING_TIMEOUT = 600000; // 10 minutes
+export const POLLING_INTERVAL = 1000; // 1 second
 export const IDEMPOTENCY_KEY_HEADER = "Idempotency-Key";

--- a/test/specs/cancels.specs.ts
+++ b/test/specs/cancels.specs.ts
@@ -4,7 +4,7 @@ import sinon, { SinonSandbox } from "sinon";
 import { v4 as uuid } from "uuid";
 
 import { HTTPMethod, RestAPI } from "../../src/api/RestAPI";
-import { POLLING_TIMEOUT } from "../../src/common/constants";
+import { POLLING_INTERVAL, POLLING_TIMEOUT } from "../../src/common/constants";
 import { RequestError } from "../../src/errors/RequestResponseError";
 import { TimeoutError } from "../../src/errors/TimeoutError";
 import { CancelCreateParams, Cancels, CancelStatus } from "../../src/resources/Cancels";
@@ -108,7 +108,11 @@ describe("Cancels", () => {
                 }
             );
 
-            await expect(cancels.poll(uuid(), uuid(), uuid())).to.eventually.eql(recordData);
+            const request = cancels.poll(uuid(), uuid(), uuid());
+            await sandbox.clock.tickAsync(POLLING_INTERVAL);
+            await sandbox.clock.tickAsync(POLLING_INTERVAL);
+
+            await expect(request).to.eventually.eql(recordData);
         });
 
         it("should timeout polling", async () => {

--- a/test/specs/charges.specs.ts
+++ b/test/specs/charges.specs.ts
@@ -4,7 +4,7 @@ import sinon, { SinonSandbox } from "sinon";
 import { v4 as uuid } from "uuid";
 
 import { HTTPMethod, RestAPI } from "../../src/api/RestAPI";
-import { POLLING_TIMEOUT } from "../../src/common/constants";
+import { POLLING_INTERVAL, POLLING_TIMEOUT } from "../../src/common/constants";
 import { RequestError } from "../../src/errors/RequestResponseError";
 import { TimeoutError } from "../../src/errors/TimeoutError";
 import { ChargeCreateParams, Charges, ChargeStatus } from "../../src/resources/Charges";
@@ -130,7 +130,11 @@ describe("Charges", () => {
                 }
             );
 
-            await expect(charges.poll(uuid(), uuid())).to.eventually.eql(recordData);
+            const request = charges.poll(uuid(), uuid());
+            await sandbox.clock.tickAsync(POLLING_INTERVAL);
+            await sandbox.clock.tickAsync(POLLING_INTERVAL);
+
+            await expect(request).to.eventually.eql(recordData);
         });
 
         it("should timeout polling", async () => {

--- a/test/specs/refunds.specs.ts
+++ b/test/specs/refunds.specs.ts
@@ -5,7 +5,7 @@ import { SinonSandbox } from "sinon";
 import { v4 as uuid } from "uuid";
 
 import { HTTPMethod, RestAPI } from "../../src/api/RestAPI";
-import { POLLING_TIMEOUT } from "../../src/common/constants";
+import { POLLING_INTERVAL, POLLING_TIMEOUT } from "../../src/common/constants";
 import { RequestError } from "../../src/errors/RequestResponseError";
 import { TimeoutError } from "../../src/errors/TimeoutError";
 import {
@@ -135,7 +135,11 @@ describe("Refunds", () => {
                 }
             );
 
-            await expect(refunds.poll(uuid(), uuid(), uuid())).to.eventually.eql(recordData);
+            const request = refunds.poll(uuid(), uuid(), uuid());
+            await sandbox.clock.tickAsync(POLLING_INTERVAL);
+            await sandbox.clock.tickAsync(POLLING_INTERVAL);
+
+            await expect(request).to.eventually.eql(recordData);
         });
 
         it("should timeout polling", async () => {

--- a/test/specs/subscriptions.specs.ts
+++ b/test/specs/subscriptions.specs.ts
@@ -5,7 +5,7 @@ import { SinonSandbox } from "sinon";
 import { v4 as uuid } from "uuid";
 
 import { HTTPMethod, RestAPI } from "../../src/api/RestAPI";
-import { POLLING_TIMEOUT } from "../../src/common/constants";
+import { POLLING_INTERVAL, POLLING_TIMEOUT } from "../../src/common/constants";
 import { RequestError } from "../../src/errors/RequestResponseError";
 import { TimeoutError } from "../../src/errors/TimeoutError";
 import {
@@ -144,7 +144,11 @@ describe("Subscriptions", () => {
                 }
             );
 
-            await expect(subscriptions.poll(uuid(), uuid())).to.eventually.eql(recordData);
+            const request = subscriptions.poll(uuid(), uuid());
+            await sandbox.clock.tickAsync(POLLING_INTERVAL);
+            await sandbox.clock.tickAsync(POLLING_INTERVAL);
+
+            await expect(request).to.eventually.eql(recordData);
         });
 
         it("should timeout polling", async () => {


### PR DESCRIPTION
No associated ticket. Our `longPoll` doesn't actually have intervals so it actually rapid-fires the endpoint until the desired result is achieved... which may not be a good idea for the API. 🤔 