### PR TITLE
Add bimonthly to subscription periods

### DIFF
--- a/src/resources/Subscriptions.ts
+++ b/src/resources/Subscriptions.ts
@@ -16,6 +16,7 @@ export enum SubscriptionPeriod {
     WEEKLY = "weekly",
     BIWEEKLY = "biweekly",
     MONTHLY = "monthly",
+    BIMONTHLY = "bimonthly",
     QUARTERLY = "quarterly",
     SEMIANNUALLY = "semiannually",
     ANNUALLY = "annually",


### PR DESCRIPTION
Updates https://github.com/univapaycast/gopay-checkout/issues/605

According to the enum file in API: https://github.com/univapaycast/gyron-payments-api/blob/develop/event/src/main/scala/payments/types/charges/SubscriptionPeriod.scala

