### PR TITLE
Add missing error response

### DIFF
--- a/src/errors/APIError.ts
+++ b/src/errors/APIError.ts
@@ -136,6 +136,7 @@ export enum ResponseErrorCode {
     DisabledPaymentType = "DISABLED_PAYMENT_TYPE",
     CardBrandNotSupported = "CARD_BRAND_NOT_SUPPORTED",
     CardCountryNotSupported = "CARD_COUNTRY_NOT_SUPPORTED",
+    CurrencyNotSupported = "CURRENCY_NOT_SUPPORTED",
     CVVRequired = "CVV_REQUIRED",
     LastNameRequired = "LAST_NAME_REQUIRED",
     AuthNotSupported = "AUTH_NOT_SUPPORTED",


### PR DESCRIPTION
Although the currency for gateway simulation is working, the error message is not translated as it was missing.