### PR TITLE
Rename alipay connect online to alipay plus online

### DIFF
--- a/src/resources/common/enums.ts
+++ b/src/resources/common/enums.ts
@@ -120,9 +120,14 @@ export enum QRGateway {
 
 export enum OnlineBrand {
     ALIPAY_ONLINE = "alipay_online",
-    ALIPAY_CONNECT_ONLINE = "alipay_connect_online",
+    ALIPAY_PLUS_ONLINE = "alipay_plus_online",
     PAY_PAY_ONLINE = "pay_pay_online",
     WE_CHAT_ONLINE = "we_chat_online",
+
+    /**
+     * @deprecated Use `ALIPAY_PLUS_ONLINE` instead
+     */
+    ALIPAY_CONNECT_ONLINE = "alipay_connect_online",
 }
 
 /**


### PR DESCRIPTION
No ticket linked to this PR. Renaming `alipay_connect_online` to `alipay_plus_online`. Old gateway is kept but deprecated for backward compatibility.