### PR TITLE
Switch to nodenext module

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+coverage
+dist

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -2,6 +2,9 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
-    "outDir": "./dist/cjs"
+    "outDir": "./dist/cjs",
+    "paths": {
+      "*": ["types/*.d.cts"]
+    }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,8 +6,7 @@
     "importHelpers": true,
     "sourceMap": true,
     "target": "es5",
-    "module": "esnext",
-    "moduleResolution": "node",
+    "module": "nodenext",
     "declaration": true,
     "allowJs": false,
     "checkJs": false,
@@ -31,10 +30,7 @@
     "strictNullChecks": false,
     "suppressImplicitAnyIndexErrors": true,
     "baseUrl": ".",
-    "outDir": "./dist/esm",
-    "paths": {
-      "*": ["types/*"]
-    }
+    "outDir": "./dist/esm"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,10 @@
     "strictNullChecks": false,
     "suppressImplicitAnyIndexErrors": true,
     "baseUrl": ".",
-    "outDir": "./dist/esm"
+    "outDir": "./dist/esm",
+    "paths": {
+      "*": ["types/*.d.ts"]
+    }
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/types/jwt-decode.d.cts
+++ b/types/jwt-decode.d.cts
@@ -23,6 +23,9 @@ declare namespace jwtDecode {
     export { InvalidTokenError, JwtDecodeOptions, JwtHeader, JwtPayload };
 }
 
-declare function jwtDecode<T = unknown>(token: string, options?: JwtDecodeOptions): T;
+declare function jwtDecode<T = unknown>(
+    token: string,
+    options?: JwtDecodeOptions
+): T;
 
 export = jwtDecode;

--- a/types/jwt-decode.d.cts
+++ b/types/jwt-decode.d.cts
@@ -1,0 +1,28 @@
+declare class InvalidTokenError extends Error {}
+
+declare interface JwtDecodeOptions {
+    header?: boolean;
+}
+
+declare interface JwtHeader {
+    typ?: string;
+    alg?: string;
+}
+
+declare interface JwtPayload {
+    iss?: string;
+    sub?: string;
+    aud?: string[] | string;
+    exp?: number;
+    nbf?: number;
+    iat?: number;
+    jti?: string;
+}
+
+declare namespace jwtDecode {
+    export { InvalidTokenError, JwtDecodeOptions, JwtHeader, JwtPayload };
+}
+
+declare function jwtDecode<T = unknown>(token: string, options?: JwtDecodeOptions): T;
+
+export = jwtDecode;

--- a/types/jwt-decode.d.ts
+++ b/types/jwt-decode.d.ts
@@ -1,0 +1,24 @@
+export declare class InvalidTokenError extends Error {}
+
+export declare interface JwtDecodeOptions {
+    header?: boolean;
+}
+
+export declare interface JwtHeader {
+    typ?: string;
+    alg?: string;
+}
+
+export declare interface JwtPayload {
+    iss?: string;
+    sub?: string;
+    aud?: string[] | string;
+    exp?: number;
+    nbf?: number;
+    iat?: number;
+    jti?: string;
+}
+
+declare function jwtDecode<T = unknown>(token: string, options?: JwtDecodeOptions): T;
+
+export default jwtDecode;


### PR DESCRIPTION
Merging this will ensure we maintain compatibility with `nodenext` modules (for example, we don't forget to add `.js` extensions).
Unfortunately, this is currently blocked by https://github.com/auth0/jwt-decode/pull/130, and maybe even by `ts-node`, so keeping it as a draft