### PR TITLE
Allow api.send to override endpoint

### DIFF
--- a/src/api/RestAPI.ts
+++ b/src/api/RestAPI.ts
@@ -208,7 +208,7 @@ export class RestAPI extends EventEmitter {
         };
 
         const request: Request = new Request(
-            `${this.endpoint}${uri}${payload ? "" : stringifyParams(data)}`,
+            `${/^https?:\/\//.test(uri) ? uri : `${this.endpoint}${uri}`}${payload ? "" : stringifyParams(data)}`,
             payload ? { ...params, body: getRequestBody(data, keyFormatter) } : params
         );
 

--- a/test/specs/api.specs.ts
+++ b/test/specs/api.specs.ts
@@ -95,6 +95,32 @@ describe("API", function () {
         expect(response).to.eql(okResponse);
     });
 
+    it("should send request to the specified http endpoint", async function () {
+        fetchMock.getOnce("http://test.univapay.com/ok", {
+            status: 200,
+            body: okResponse,
+            headers: { "Content-Type": "application/json" },
+        });
+
+        const api: RestAPI = new RestAPI({ endpoint: testEndpoint });
+        const response = await api.send(HTTPMethod.GET, "http://test.univapay.com/ok");
+
+        expect(response).to.eql(okResponse);
+    });
+
+    it("should send request to the specified https endpoint", async function () {
+        fetchMock.getOnce("https://test.univapay.com/ok", {
+            status: 200,
+            body: okResponse,
+            headers: { "Content-Type": "application/json" },
+        });
+
+        const api: RestAPI = new RestAPI({ endpoint: testEndpoint });
+        const response = await api.send(HTTPMethod.GET, "https://test.univapay.com/ok");
+
+        expect(response).to.eql(okResponse);
+    });
+
     it("should override jwt and secret from environment variable with auth parameter", async function () {
         const secret = "myActualSecret";
         const jwtToken = jwt.sign({ my: "payload" }, "foo");


### PR DESCRIPTION
I noticed a hack in the `oneTouch` API for overriding the endpoint.
Trying to formalize this here, will send a PR to the private SDK shortly with the second half.
This should be released as `2.1`