### PR TITLE
Add link product route on public sdk

### DIFF
--- a/src/resources/LinksProducts.ts
+++ b/src/resources/LinksProducts.ts
@@ -9,7 +9,6 @@ import { TransactionTokenType } from "./TransactionTokens.js";
 
 export type LinkProductListItem = {
     id: string;
-    platformId: string;
     merchantId: string;
     storeId: string;
     name: string;

--- a/src/resources/LinksProducts.ts
+++ b/src/resources/LinksProducts.ts
@@ -1,0 +1,38 @@
+/**
+ *  @module Resources/Products
+ */
+
+import { AuthParams, SendData } from "../api/RestAPI.js";
+import { CRUDItemsResponse, CRUDResource } from "./CRUDResource.js";
+import { DefinedRoute } from "./Resource.js";
+import { TransactionTokenType } from "./TransactionTokens.js";
+
+export type LinkProductListItem = {
+    id: string;
+    platformId: string;
+    merchantId: string;
+    storeId: string;
+    name: string;
+    description?: string | null;
+    amount: number;
+    currency: string;
+    shippingFees?: number | null;
+    tokenType: TransactionTokenType;
+    createdOn: string;
+    updatedOn: string;
+    code: string | null;
+    quantity: number;
+};
+export type ResponseLinkProducts = CRUDItemsResponse<LinkProductListItem> & {
+    hasMore: false; // no support for pagination
+};
+
+export class LinksProducts extends CRUDResource {
+    static routeBase = "/checkout/links/:linkId/products";
+
+    private _list?: DefinedRoute;
+    list(linkId: string, data?: SendData<{ [k: string]: never }>, auth?: AuthParams): Promise<ResponseLinkProducts> {
+        this._list = this._list ?? this._listRoute();
+        return this._list(data, auth, { linkId });
+    }
+}

--- a/test/fixtures/links-products.ts
+++ b/test/fixtures/links-products.ts
@@ -4,7 +4,6 @@ import { LinkProductListItem } from "../../src/resources/LinksProducts.js";
 
 export const generateFixture = (): LinkProductListItem => ({
     id: uuid(),
-    platformId: uuid(),
     merchantId: uuid(),
     storeId: uuid(),
     name: "dummy product",

--- a/test/fixtures/links-products.ts
+++ b/test/fixtures/links-products.ts
@@ -1,0 +1,20 @@
+import { v4 as uuid } from "uuid";
+import { TransactionTokenType } from "../../src/resources/TransactionTokens.js";
+import { LinkProductListItem } from "../../src/resources/LinksProducts.js";
+
+export const generateFixture = (): LinkProductListItem => ({
+    id: uuid(),
+    platformId: uuid(),
+    merchantId: uuid(),
+    storeId: uuid(),
+    name: "dummy product",
+    description: null,
+    amount: 100,
+    currency: "JPY",
+    shippingFees: null,
+    tokenType: TransactionTokenType.ONE_TIME,
+    createdOn: new Date().toISOString(),
+    updatedOn: new Date().toISOString(),
+    code: null,
+    quantity: 1,
+});

--- a/test/specs/links-products.specs.ts
+++ b/test/specs/links-products.specs.ts
@@ -1,0 +1,41 @@
+import { expect } from "chai";
+import fetchMock from "fetch-mock";
+import { v4 as uuid } from "uuid";
+
+import { RestAPI } from "../../src/api/RestAPI.js";
+import { generateList } from "../fixtures/list.js";
+import { generateFixture as generateLinkItemFixture } from "../fixtures/links-products.js";
+import { testEndpoint } from "../utils/index.js";
+import { pathToRegexMatcher } from "../utils/routes.js";
+
+import { LinksProducts } from "../../src/resources/LinksProducts.js";
+
+describe("Links Products", () => {
+    let api: RestAPI;
+    let linksProducts: LinksProducts;
+
+    const recordBasePathMatcher = pathToRegexMatcher(`${testEndpoint}/checkout/links/:linkId/products`);
+
+    beforeEach(() => {
+        api = new RestAPI({ endpoint: testEndpoint });
+        linksProducts = new LinksProducts(api);
+    });
+
+    afterEach(() => {
+        fetchMock.restore();
+    });
+
+    context("GET (/merchants/:merchantId)(/stores/:storeId)/checkout/links/:linkId/products", () => {
+        it("should get response", async () => {
+            const listData = generateList({ count: 10, recordGenerator: generateLinkItemFixture });
+
+            fetchMock.get(recordBasePathMatcher, {
+                status: 200,
+                body: listData,
+                headers: { "Content-Type": "application/json" },
+            });
+
+            expect(linksProducts.list(uuid())).to.become(listData);
+        });
+    });
+});


### PR DESCRIPTION
Open the link product route on the private SDK for checkout usage 🙂 

@perrin4869 Would it be possible to ensure that the route would work without a storeId and merchantId in the pathname, using the store application token as auth? Sorry that I missed that check during the previous review.