### PR TITLE
Fix ec language types

### DIFF
--- a/src/resources/ECForms.ts
+++ b/src/resources/ECForms.ts
@@ -23,9 +23,9 @@ export enum ECFormCustomFieldType {
 }
 
 export enum Languages {
-    EN_US = "enUs",
-    JA_JP = "jaJp",
-    ZH_TW = "zhTw",
+    EN_US = "en_us",
+    JA_JP = "ja_jp",
+    ZH_TW = "zh_tw",
 }
 
 export type ECFormCustomField = {
@@ -125,7 +125,8 @@ export class ECForms extends CRUDResource {
 
     private _get?: DefinedRoute;
     get(id: string, data?: SendData<void>, auth?: AuthParams): Promise<ResponseECForm> {
-        this._get = this._get ?? this._getRoute();
+        const ignoreKeysFormatting = ["metadata", ...Object.values(Languages)];
+        this._get = this._get ?? this._getRoute({ ignoreKeysFormatting });
         return this._get(data, auth, { id });
     }
 }

--- a/src/resources/ECForms.ts
+++ b/src/resources/ECForms.ts
@@ -23,9 +23,9 @@ export enum ECFormCustomFieldType {
 }
 
 export enum Languages {
-    EN_US = "en_us",
-    JA_JP = "ja_jp",
-    ZH_TW = "zh_tw",
+    EN_US = "enUs",
+    JA_JP = "jaJp",
+    ZH_TW = "zhTw",
 }
 
 export type ECFormCustomField = {

--- a/src/resources/ECInfo.ts
+++ b/src/resources/ECInfo.ts
@@ -5,7 +5,7 @@ import { AuthParams, SendData } from "../api/RestAPI.js";
 
 import { CRUDResource } from "./CRUDResource.js";
 import { ECFormLinkItem } from "./ECFormLinks.js";
-import { ECFormItem } from "./ECForms.js";
+import { ECFormItem, Languages } from "./ECForms.js";
 import { DefinedRoute } from "./Resource.js";
 
 export type ECInfoItem = {
@@ -21,7 +21,8 @@ export class ECInfo extends CRUDResource {
 
     private _get?: DefinedRoute;
     get(id: string, data?: SendData<ECInfoGetParams>, auth?: AuthParams): Promise<ResponseECInfo> {
-        this._get = this._get ?? this._getRoute();
+        const ignoreKeysFormatting = ["metadata", ...Object.values(Languages)];
+        this._get = this._get ?? this._getRoute({ ignoreKeysFormatting });
         return this._get(data, auth, { id });
     }
 }

--- a/test/fixtures/ec-form.ts
+++ b/test/fixtures/ec-form.ts
@@ -1,8 +1,16 @@
 import { v4 as uuid } from "uuid";
 
 import { OnlineBrand } from "../../src/resources/common/enums.js";
-import { CheckoutType, ECFormItem } from "../../src/resources/ECForms.js";
+import { CheckoutType, ECFormCustomField, ECFormItem, ECFormCustomFieldType } from "../../src/resources/ECForms.js";
 import { PaymentType, TransactionTokenType } from "../../src/resources/TransactionTokens.js";
+
+const generateECFormCustomField = (): ECFormCustomField => ({
+    key: "test-key",
+    label: "Test label",
+    type: ECFormCustomFieldType.SELECT,
+    required: false,
+    options: ["Test option 1", "Test option 2"],
+});
 
 export const generateFixture = (): ECFormItem => ({
     id: uuid(),
@@ -54,7 +62,23 @@ export const generateFixture = (): ECFormItem => ({
     /* Metadata */
     descriptor: "dummy-descriptor",
     ignoreDescriptorOnError: false,
+
     metadata: {
-        test: "dummy-data",
+        "test-test": "dummy-data",
+    },
+    customFieldsTitles: {
+        en_us: "Test english field title",
+        ja_jp: "Test japanese field title",
+        zh_tw: "Test taiwanese field title",
+    },
+    orderSummaryTitles: {
+        en_us: "Test englishorder  title",
+        ja_jp: "Test japanese order title",
+        zh_tw: "Test taiwanese order title",
+    },
+    customFields: {
+        en_us: [generateECFormCustomField()],
+        ja_jp: [generateECFormCustomField()],
+        zh_tw: [generateECFormCustomField()],
     },
 });

--- a/test/specs/ec-forms.specs.ts
+++ b/test/specs/ec-forms.specs.ts
@@ -4,7 +4,7 @@ import { v4 as uuid } from "uuid";
 
 import { RestAPI } from "../../src/api/RestAPI.js";
 import { ECForms } from "../../src/resources/ECForms.js";
-import { generateFixture as generateCheckoutInfo } from "../fixtures/checkout-info.js";
+import { generateFixture as generateECForm } from "../fixtures/ec-form.js";
 import { testEndpoint } from "../utils/index.js";
 import { pathToRegexMatcher } from "../utils/routes.js";
 
@@ -12,7 +12,7 @@ describe("EC Forms", () => {
     let api: RestAPI;
     let ecForms: ECForms;
 
-    const recordData = generateCheckoutInfo();
+    const recordData = generateECForm();
     const recordPathMatcher = pathToRegexMatcher(`${testEndpoint}/checkout/forms/:id`);
 
     beforeEach(() => {

--- a/test/specs/ec-info.specs.ts
+++ b/test/specs/ec-info.specs.ts
@@ -5,14 +5,14 @@ import { v4 as uuid } from "uuid";
 
 import { RestAPI } from "../../src/api/RestAPI.js";
 import { ECInfo } from "../../src/resources/index.js";
-import { generateFixture as generateCheckoutInfo } from "../fixtures/ec-info.js";
+import { generateFixture as generateECInfo } from "../fixtures/ec-info.js";
 import { testEndpoint } from "../utils/index.js";
 
 describe("EC Info", () => {
     let api: RestAPI;
     let ecInfo: ECInfo;
 
-    const recordData = generateCheckoutInfo();
+    const recordData = generateECInfo();
     const recordPathMatcher = new RegExp(
         `^${testEndpoint}${pathToRegexp("/checkout/info/:id", [], { start: false, end: false }).source}`
     );


### PR DESCRIPTION
Used in the following type:

```
customFieldsTitles?: Partial<Record<Languages, string>> | null;
orderSummaryTitles?: Partial<Record<Languages, string>> | null;
customFields?: Partial<Record<Languages, ECFormCustomField[]>> | null;
```

The keys for those items are camelized on the SDK and snakified when formatting for the API. When using them the proper type is the camelized version as we want to use the front-end-formatted version. Please feel free to tell me if I overlook anything.