### PR TITLE
Add AUTHORIZED variant to SubscriptionStatus

### DIFF
--- a/src/resources/Subscriptions.ts
+++ b/src/resources/Subscriptions.ts
@@ -33,6 +33,7 @@ export enum SubscriptionStatus {
     CANCELED = "canceled",
     UNCONFIRMED = "unconfirmed",
     COMPLETED = "completed",
+    AUTHORIZED = "authorized",
 }
 
 export enum InstallmentPlan {


### PR DESCRIPTION
Added `AUTHORIZED` variant to `SubscriptionStatus` enum. Required for https://github.com/univapaycast/univapay-console/issues/3026
