### PR TITLE
chore: run dependabot weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: /
     versioning-strategy: increase
     schedule:
-      interval: daily
+      interval: weekly
     ignore:
       - dependency-name: "query-string"
       - dependency-name: "arrify" # esm-only


### PR DESCRIPTION
Is `query-string` still being ignored?