### PR TITLE
Remove unsafe expiry check

### DIFF
--- a/src/api/RestAPI.ts
+++ b/src/api/RestAPI.ts
@@ -21,7 +21,7 @@ import {
 } from "../common/constants.js";
 import { RequestErrorCode, ResponseErrorCode } from "../errors/APIError.js";
 import { fromError } from "../errors/parser.js";
-import { RequestError, ResponseError } from "../errors/RequestResponseError.js";
+import { ResponseError } from "../errors/RequestResponseError.js";
 import { TimeoutError } from "../errors/TimeoutError.js";
 import { ProcessingMode } from "../resources/common/enums.js";
 import { checkStatus, parseJSON } from "../utils/fetch.js";
@@ -231,22 +231,7 @@ export class RestAPI extends EventEmitter {
         auth?: AuthParams,
         options: ApiSendOptions = {}
     ): Promise<ResponseBody | string | Blob | FormData> {
-        const {
-            requireAuth = true,
-            acceptType,
-            keyFormatter = toSnakeCase,
-            ignoreKeysFormatting = ["metadata"],
-        } = options;
-
-        const dateNow = new Date();
-        const timestampUTC = Math.round(dateNow.getTime() / 1000);
-
-        if (requireAuth && this._jwtRaw && this.jwt.exp < timestampUTC) {
-            throw new RequestError({
-                code: ResponseErrorCode.ExpiredLoginToken,
-                errors: [],
-            });
-        }
+        const { acceptType, keyFormatter = toSnakeCase, ignoreKeysFormatting = ["metadata"] } = options;
 
         const payload: boolean = [HTTPMethod.GET, HTTPMethod.DELETE].includes(method) === false;
 

--- a/test/specs/api.specs.ts
+++ b/test/specs/api.specs.ts
@@ -13,8 +13,7 @@ import {
 } from "../../src/common/constants.js";
 import { APIError, ResponseErrorCode } from "../../src/errors/APIError.js";
 import { fromError } from "../../src/errors/parser.js";
-import { RequestError, ResponseError } from "../../src/errors/RequestResponseError.js";
-import { Merchants } from "../../src/resources/Merchants.js";
+import { ResponseError } from "../../src/errors/RequestResponseError.js";
 import { isBlob } from "../../src/utils/object.js";
 import { testEndpoint } from "../utils/index.js";
 

--- a/test/specs/api.specs.ts
+++ b/test/specs/api.specs.ts
@@ -459,29 +459,6 @@ describe("API", function () {
         await expect(api.ping()).to.eventually.be.undefined;
     });
 
-    it("should throw an error if token is expired", async function () {
-        const dateNow = new Date();
-        const jwtToken = jwt.sign(
-            {
-                exp: Math.round(dateNow.getTime() / 1000) - 1000,
-                foo: "bar",
-            },
-            "foo"
-        );
-
-        const api: RestAPI = new RestAPI({ endpoint: testEndpoint, jwt: jwtToken });
-        const merchants = new Merchants(api);
-
-        const error = new RequestError({
-            code: ResponseErrorCode.ExpiredLoginToken,
-            errors: [],
-        });
-
-        const resError = await expect(merchants.me()).to.eventually.be.rejected;
-        expect(resError).to.be.instanceOf(RequestError);
-        expect(resError.errorResponse).to.eql(error.errorResponse);
-    });
-
     it("should not throw an error for open routes even if token is expired", async function () {
         const dateNow = new Date();
         const jwtToken = jwt.sign(


### PR DESCRIPTION
User system date was affecting the auth logic and would cause a token expired error even though the token is valid