### PR TITLE
Add paymentType field to SupportedBrand

### DIFF
--- a/src/resources/CheckoutInfo.ts
+++ b/src/resources/CheckoutInfo.ts
@@ -15,7 +15,7 @@ import {
 import { BankTransferBrand, CardBrand, OnlineBrand, ProcessingMode } from "./common/enums.js";
 import { AmountWithCurrency } from "./common/types.js";
 import { DefinedRoute, Resource } from "./Resource.js";
-import { OnlineCallMethod, OSType, RecurringTokenPrivilege } from "./TransactionTokens.js";
+import { OnlineCallMethod, OSType, PaymentType, RecurringTokenPrivilege } from "./TransactionTokens.js";
 
 /* Request */
 export interface CheckoutInfoParams {
@@ -42,6 +42,7 @@ export interface SupportedBrand {
     requiresCvv: boolean;
     countriesAllowed?: string[] | null;
     supportedCurrencies: string[];
+    paymentType: PaymentType;
 
     /**
      * @deprecated

--- a/test/fixtures/checkout-info.ts
+++ b/test/fixtures/checkout-info.ts
@@ -2,7 +2,7 @@ import { v4 as uuid } from "uuid";
 
 import { CheckoutInfoBrandItem, CheckoutInfoItem } from "../../src/resources/CheckoutInfo.js";
 import { CardBrand, OnlineBrand, ProcessingMode } from "../../src/resources/common/enums.js";
-import { RecurringTokenPrivilege } from "../../src/resources/TransactionTokens.js";
+import { PaymentType, RecurringTokenPrivilege } from "../../src/resources/TransactionTokens.js";
 
 import {
     generateFixtureBankTransferConfiguration,
@@ -52,6 +52,7 @@ export const generateFixture = (): CheckoutInfoItem => ({
             requiresCvv: true,
             countriesAllowed: null,
             supportedCurrencies: ["JPY"],
+            paymentType: PaymentType.CARD,
         },
     ],
 });


### PR DESCRIPTION
Updates https://github.com/univapaycast/gopay-checkout/issues/939

I can see `paymentType` field in `state.configuration.data.supportedBrands` on the widget, but cannot access it now.
And I want to use it in the above ticket, so adding it.
![Screenshot from 2023-02-10 10-12-20](https://user-images.githubusercontent.com/50436134/217975688-a139ef3d-baf6-48f3-b8df-273c76d48bd2.png)
