### PR TITLE
Remove cyrex pay from QR brands

### DIFF
--- a/src/resources/common/enums.ts
+++ b/src/resources/common/enums.ts
@@ -110,7 +110,6 @@ export enum QRGateway {
     AU_PAY = "au_pay",
     BARTONG = "bartong",
     BPI = "bpi",
-    CYREX_PAY = "cyrex_pay",
     CO = "cyrex_pay",
     D_BARAI = "d_barai",
     D_BARAI_MPM = "d_barai_mpm",


### PR DESCRIPTION
Fixes https://univapay-systems.slack.com/archives/C0172GCPT4M/p1678703575213189?thread_ts=1678703575.213189&cid=C0172GCPT4M

Cyrex pay is a card gateway and not a QR gateway. Removing it from the QR gateways will make it appear in the correct place.

Linked to https://github.com/univapaycast/univapay-common/pull/1051