### PR TITLE
Add minRefundThreshold to PMS configuration

### DIFF
--- a/src/resources/common/Configuration.ts
+++ b/src/resources/common/Configuration.ts
@@ -176,6 +176,7 @@ export interface SecurityConfiguration {
         durationWindow: string;
     };
     refundPercentLimit?: number;
+    minRefundThreshold?: number;
 }
 
 export interface UserTransactionsConfiguration {

--- a/src/resources/common/Platform.ts
+++ b/src/resources/common/Platform.ts
@@ -75,6 +75,7 @@ export interface PlatformConfiguration {
     paymentDefaults: PlatformPaymentDefaults;
     recurringCardChargeCvvConfirmationThreshold?: AmountWithCurrency[];
     refundPercentLimit: number;
+    minRefundThreshold: number;
     supportedLanguages: string[];
     timeZone: string;
     userDefaults: PlatformUserDefaults;

--- a/test/fixtures/common/configuration.ts
+++ b/test/fixtures/common/configuration.ts
@@ -98,6 +98,7 @@ export const generateFixture = (): ConfigurationItem => ({
             durationWindow: "P1M",
         },
         refundPercentLimit: 5,
+        minRefundThreshold: 5,
     },
     installmentsConfiguration: generateFixtureInstallmentConfiguration(),
     minimumChargeAmounts: [],

--- a/test/fixtures/platforms.ts
+++ b/test/fixtures/platforms.ts
@@ -50,6 +50,7 @@ export const generateFixture = (): PlatformConfigurationItem => ({
             taggedPlatformCredentialsEnabled: true,
         },
         refundPercentLimit: 5,
+        minRefundThreshold: 5,
         paymentDefaults: {
             cardsEnabled: true,
             qrScanEnabled: true,


### PR DESCRIPTION
Backend recently added a new `minRefundThreshold` field as required for platform configuration.

Related slack message here https://univapay-systems.slack.com/archives/CA0U3CSQ1/p1678703484968519
