### PR TITLE
Make both 'period' and 'cyclicalPeriod' optional on SubscriptionItem

### DIFF
--- a/src/resources/Subscriptions.ts
+++ b/src/resources/Subscriptions.ts
@@ -181,7 +181,9 @@ export type SubscriptionItem<T extends Metadata = Metadata> = {
     paymentsLeft: number;
     descriptor: string;
     onlyDirectCurrency: boolean;
-} & PeriodParams;
+    period?: SubscriptionPeriod;
+    cyclicalPeriod?: string | null;
+};
 
 export type SubscriptionListItem = WithStoreMerchantName<SubscriptionItem>;
 


### PR DESCRIPTION
Needed for https://github.com/univapaycast/univapay-console/issues/3287 cause otherwise typescript complains it cannot find `cyclicalPeriod` on `SubscriptionItem` when we try to use it on the merchant console side.