### PR TITLE
Add cyclesLeft

### DIFF
--- a/src/resources/Subscriptions.ts
+++ b/src/resources/Subscriptions.ts
@@ -184,6 +184,7 @@ export type SubscriptionItem<T extends Metadata = Metadata> = {
     onlyDirectCurrency: boolean;
     period?: SubscriptionPeriod;
     cyclicalPeriod?: string | null;
+    cyclesLeft?: number;
 };
 
 export type SubscriptionListItem = WithStoreMerchantName<SubscriptionItem>;


### PR DESCRIPTION
Updates https://github.com/univapaycast/univapay-console/issues/2547
I can see `cyclesLeft` in the log, but I cannot access it on the merchant console now.
I want to use to calculate the number of cycles that alread done, so add it.

![Screenshot from 2023-06-20 13-27-48](https://github.com/univapay/univapay-node/assets/50436134/d643390d-e8b2-4874-a573-73a8ee8d6710)
