### PR TITLE
Add platformId to ChargeItem

### DIFF
--- a/src/resources/Charges.ts
+++ b/src/resources/Charges.ts
@@ -55,6 +55,7 @@ export type ChargeIssuerTokenGetParams = void;
 /* Response */
 export interface ChargeItem<T extends Metadata = Metadata> {
     id: string;
+    platformId: string;
     merchantId: string;
     storeId: string;
     ledgerId?: string;

--- a/test/fixtures/charge.ts
+++ b/test/fixtures/charge.ts
@@ -6,6 +6,7 @@ import { TransactionTokenType } from "../../src/resources/TransactionTokens.js";
 
 export const generateFixture = (overrides?: Partial<ChargeItem>): ChargeItem => ({
     id: uuid(),
+    platformId: uuid(),
     merchantId: uuid(),
     storeId: uuid(),
     transactionTokenId: uuid(),


### PR DESCRIPTION
Updates https://github.com/univapaycast/univapay-form-checkout/issues/625

Adding platformId to ChargeItem to be able to get platform information based on charge.