### PR TITLE
Remove platformId from ChargeItem

### DIFF
--- a/src/resources/Charges.ts
+++ b/src/resources/Charges.ts
@@ -55,7 +55,6 @@ export type ChargeIssuerTokenGetParams = void;
 /* Response */
 export interface ChargeItem<T extends Metadata = Metadata> {
     id: string;
-    platformId: string;
     merchantId: string;
     storeId: string;
     ledgerId?: string;

--- a/test/fixtures/charge.ts
+++ b/test/fixtures/charge.ts
@@ -6,7 +6,6 @@ import { TransactionTokenType } from "../../src/resources/TransactionTokens.js";
 
 export const generateFixture = (overrides?: Partial<ChargeItem>): ChargeItem => ({
     id: uuid(),
-    platformId: uuid(),
     merchantId: uuid(),
     storeId: uuid(),
     transactionTokenId: uuid(),


### PR DESCRIPTION
Reverting https://github.com/univapay/univapay-node/pull/860 because it is not needed to get platform informations.
(See https://github.com/univapaycast/univapay-form-checkout/pull/640)