### PR TITLE
Allow string metadata for transactions

### DIFF
--- a/src/resources/Charges.ts
+++ b/src/resources/Charges.ts
@@ -39,17 +39,22 @@ export interface ChargeCreateParams<T extends Metadata = Metadata> {
     transactionTokenId: string;
     amount: number;
     currency: string;
+
     captureAt?: string | number;
     capture?: boolean;
     descriptor?: string;
     ignoreDescriptorOnError?: boolean;
     onlyDirectCurrency?: boolean;
-    metadata?: T;
     redirect?: {
         endpoint: string;
     };
     feeAmount?: number | null;
     feeCurrency?: string | null;
+
+    /**
+     * Metadata or stringified JSON object
+     */
+    metadata?: T | string;
 }
 
 export type ChargeIssuerTokenGetParams = void;
@@ -59,31 +64,36 @@ export interface ChargeItem<T extends Metadata = Metadata> {
     id: string;
     merchantId: string;
     storeId: string;
-    ledgerId?: string;
-    subscriptionId?: string;
+    mode: ProcessingMode;
+    transactionTokenType: TransactionTokenType;
+    status: ChargeStatus;
+    createdOn: string;
+    descriptor: string;
+    onlyDirectCurrency: boolean;
     requestedAmount: number;
     requestedCurrency: string;
     requestedAmountFormatted: number;
     chargedAmount: number;
     chargedCurrency: string;
     chargedAmountFormatted: number;
+
+    ledgerId?: string;
+    subscriptionId?: string;
     captureAt?: string;
     captureStatus?: CaptureStatus;
-    status: ChargeStatus;
     error?: PaymentError;
-    metadata?: T;
-    mode: ProcessingMode;
-    createdOn: string;
     transactionTokenId?: string;
-    transactionTokenType: TransactionTokenType;
-    descriptor: string;
-    onlyDirectCurrency: boolean;
     redirect?: {
         redirectId?: string;
     };
     feeAmount?: number | null;
     feeCurrency?: string | null;
     feeAmountFormatted?: string | null;
+
+    /**
+     * Metadata or stringified JSON object
+     */
+    metadata?: T | string;
 }
 export interface IssuerTokenItem {
     issuerToken: string;

--- a/src/resources/Refunds.ts
+++ b/src/resources/Refunds.ts
@@ -33,14 +33,18 @@ export interface RefundCreateParams<T extends Metadata = Metadata> {
     currency: string;
     reason?: RefundReason;
     message?: string;
-    metadata?: T;
+    metadata?: T | string;
 }
 
 export interface RefundUpdateParams<T extends Metadata = Metadata> {
     status?: RefundStatus;
     reason?: RefundReason;
     message?: string;
-    metadata?: T;
+
+    /**
+     * Metadata or stringified JSON object
+     */
+    metadata?: T | string;
 }
 
 /* Response */
@@ -56,7 +60,11 @@ export interface RefundItem<T extends Metadata = Metadata> {
     reason?: RefundReason;
     message?: string;
     error?: PaymentError;
-    metadata?: T;
+
+    /**
+     * Metadata or stringified JSON object
+     */
+    metadata?: T | string;
     mode: ProcessingMode;
     createdOn: string;
 }

--- a/src/resources/Subscriptions.ts
+++ b/src/resources/Subscriptions.ts
@@ -87,11 +87,15 @@ export type SubscriptionCreateBaseParams<T extends Metadata = Metadata> = {
     amount: number;
     currency: string;
     descriptor?: string;
-    metadata?: T;
     initialAmount?: number;
     installmentPlan?: InstallmentPlanItem;
     subscriptionPlan?: SubscriptionPlanItem;
     onlyDirectCurrency?: boolean;
+
+    /**
+     * Metadata or stringified JSON object
+     */
+    metadata?: T | string;
 
     /**
      * Interval (e.g: P7D)
@@ -119,10 +123,14 @@ export type SubscriptionUpdateParams<T extends Metadata = Metadata> = {
     transactionTokenId?: string;
     amount?: number;
     status?: SubscriptionStatus;
-    metadata?: T;
     installmentPlan?: Partial<InstallmentPlanItem>;
     subscriptionPlan?: Partial<SubscriptionPlanItem>;
     onlyDirectCurrency?: boolean;
+
+    /**
+     * Metadata or stringified JSON object
+     */
+    metadata?: T | string;
 
     /**
      * Interval (e.g: P7D)
@@ -162,29 +170,34 @@ type PeriodParams =
 export type SubscriptionItem<T extends Metadata = Metadata> = {
     id: string;
     storeId: string;
+    transactionTokenId: string;
+    mode: ProcessingMode;
+    status: SubscriptionStatus;
     amount: number;
     amountFormatted: number;
     amountLeft: number;
     amountLeftFormatted: number;
     currency: string;
-    initialAmount?: number | null;
-    initialAmountFormatted?: number;
-    subsequentCyclesStart?: string;
-    scheduleSettings: ScheduleSettings | null;
-    status: SubscriptionStatus;
-    metadata?: T;
-    mode: ProcessingMode;
-    createdOn: string;
-    installmentPlan?: InstallmentPlanItem;
-    subscriptionPlan?: SubscriptionPlanItem;
-    transactionTokenId: string;
-    nextPayment: ScheduledPaymentItem;
     paymentsLeft: number;
     descriptor: string;
     onlyDirectCurrency: boolean;
+    createdOn: string;
+    scheduleSettings: ScheduleSettings | null;
+    nextPayment: ScheduledPaymentItem;
+
+    initialAmount?: number | null;
+    initialAmountFormatted?: number;
+    subsequentCyclesStart?: string;
+    installmentPlan?: InstallmentPlanItem;
+    subscriptionPlan?: SubscriptionPlanItem;
     period?: SubscriptionPeriod;
     cyclicalPeriod?: string | null;
     cyclesLeft?: number;
+
+    /**
+     * Metadata or stringified JSON object
+     */
+    metadata?: T | string;
 };
 
 export type SubscriptionListItem = WithStoreMerchantName<SubscriptionItem>;

--- a/src/resources/TransactionTokens.ts
+++ b/src/resources/TransactionTokens.ts
@@ -180,7 +180,7 @@ export type TransactionTokenBankTransferCreateData = {
     expirationPeriod?: string;
 };
 
-export interface TransactionTokenCreateParams<T extends Metadata = Metadata> {
+export interface TransactionTokenCreateParams {
     paymentType: PaymentType;
     type: TransactionTokenType;
     email?: string;
@@ -192,8 +192,12 @@ export interface TransactionTokenCreateParams<T extends Metadata = Metadata> {
         | TransactionTokenOnlineData
         | TransactionTokenPaidyData
         | TransactionTokenBankTransferCreateData;
-    metadata?: T;
     useConfirmation?: boolean;
+
+    /**
+     * Metadata or stringified JSON object
+     */
+    metadata?: Metadata | string;
 }
 
 export interface TransactionTokenListParams extends CRUDPaginationParams {
@@ -203,7 +207,7 @@ export interface TransactionTokenListParams extends CRUDPaginationParams {
     mode?: ProcessingMode;
 }
 
-export interface TransactionTokenUpdateParams<T extends Metadata = Metadata> {
+export interface TransactionTokenUpdateParams {
     email?: string;
     data?: {
         cvv?: string;
@@ -224,7 +228,11 @@ export interface TransactionTokenUpdateParams<T extends Metadata = Metadata> {
         expirationPeriod?: string;
         expirationTimeShift?: string;
     };
-    metadata?: T;
+
+    /**
+     * Metadata or stringified JSON object
+     */
+    metadata?: Metadata | string;
 }
 
 export interface TransactionTokenConfirmParams {
@@ -297,7 +305,7 @@ export interface TransactionTokenConvenienceDataItem extends TransactionTokenBas
     expirationTimeShift?: string;
     phoneNumber?: PhoneNumber;
 }
-export interface TransactionTokenItem<T extends Metadata = Metadata> {
+export interface TransactionTokenItem {
     id: string;
     storeId: string;
     email: string;
@@ -316,7 +324,11 @@ export interface TransactionTokenItem<T extends Metadata = Metadata> {
         | TransactionTokenPaidyData
         | TransactionTokenBankTransferData
     ) & { cvvAuthorize?: { status: CvvAuthorizedStatus } };
-    metadata?: T;
+
+    /**
+     * Metadata or stringified JSON object
+     */
+    metadata?: Metadata | string;
 }
 
 export type TransactionTokenListItem = WithStoreMerchantName<TransactionTokenItem>;

--- a/src/resources/common/types.ts
+++ b/src/resources/common/types.ts
@@ -27,7 +27,7 @@ export interface PhoneNumber {
 }
 
 export interface Metadata {
-    [key: string]: any;
+    [key: string]: string | number | bigint | boolean | (string | number | bigint | boolean)[];
 }
 
 export interface InvoiceChargeFee {


### PR DESCRIPTION
String metadata are allow for transaction as JSON objects. Fixing the types there.