### PR TITLE
feat: increase target of tsc to es2022

### DIFF
--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -3,8 +3,11 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "./dist/cjs",
+    "target": "es2020",
     "paths": {
-      "*": ["types/*.d.cts"]
+      "*": [
+        "types/*.d.cts"
+      ]
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "downlevelIteration": true,
     "importHelpers": true,
     "sourceMap": true,
-    "target": "es2020",
+    "target": "es2022",
     "module": "nodenext",
     "declaration": true,
     "allowJs": false,
@@ -31,9 +31,15 @@
     "baseUrl": ".",
     "outDir": "./dist/esm",
     "paths": {
-      "*": ["types/*.d.ts"]
+      "*": [
+        "types/*.d.ts"
+      ]
     }
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
So @gdp88 was trying to use `sinon` to mock the sdk, but was encountering issues. The root cause is that the SDK was still compiling down to an old version of `es` and was producing:

```
export default class SDK extends PaymentsSDK {
    constructor() {
        super(...arguments);
        this.bankAccounts = new BankAccounts(this.api);
        this.cancels = new Cancels(this.api);
        this.captures = new Captures(this.api);
        this.charges = new Charges(this.api);
        this.checkoutInfo = new CheckoutInfo(this.api);
        this.ecInfo = new ECInfo(this.api);
        this.ecFormLinks = new ECFormLinks(this.api);
        this.ecForms = new ECForms(this.api);
        this.ecLinksProducts = new LinksProducts(this.api);
        this.emails = new Emails(this.api);
        this.exchangeRates = new ExchangeRates(this.api);
        this.ledgers = new Ledgers(this.api);
        this.merchants = new Merchants(this.api);
        this.platforms = new Platforms(this.api);
        this.products = new Products(this.api);
        this.refers = new Refers(this.api);
        this.refunds = new Refunds(this.api);
        this.stores = new Stores(this.api);
        this.subscriptions = new Subscriptions(this.api);
        this.transactionTokens = new TransactionTokens(this.api);
        this.transfers = new Transfers(this.api);
        this.verification = new Verification(this.api);
        this.webHooks = new WebHooks(this.api);
    }
}
```

instead of

```
export default class SDK extends PaymentsSDK {
    bankAccounts = new BankAccounts(this.api);
    cancels = new Cancels(this.api);
    captures = new Captures(this.api);
    charges = new Charges(this.api);
    checkoutInfo = new CheckoutInfo(this.api);
    ecInfo = new ECInfo(this.api);
    ecFormLinks = new ECFormLinks(this.api);
    ecForms = new ECForms(this.api);
    ecLinksProducts = new LinksProducts(this.api);
    emails = new Emails(this.api);
    exchangeRates = new ExchangeRates(this.api);
    ledgers = new Ledgers(this.api);
    merchants = new Merchants(this.api);
    platforms = new Platforms(this.api);
    products = new Products(this.api);
    refers = new Refers(this.api);
    refunds = new Refunds(this.api);
    stores = new Stores(this.api);
    subscriptions = new Subscriptions(this.api);
    transactionTokens = new TransactionTokens(this.api);
    transfers = new Transfers(this.api);
    verification = new Verification(this.api);
    webHooks = new WebHooks(this.api);
}
```

Setting the properties inside the contructor makes them invisible because they are not part of the prototype until the contructor is actually run. You can see here in this experiment I ran inside the repl:

```
Welcome to Node.js v20.11.0.
Type ".help" for more information.
> const { createStubInstance } = require('sinon');
undefined
> createStubInstance
[Function: createStubInstance]
> class Foo { bar() {} }
undefined
> const { stub } = require('sinon');
undefined
> const foo = createStubInstance(Foo, { bar: stub().returns("omg") })
undefined
> foo.bar()
'omg'
> class Foo2 { constructor() { this.bar = () => {} } }
undefined
> const foo2 = createStubInstance(Foo2, { bar: stub().returns("omg") })
Uncaught Error: Found no methods on object to which we could apply mutations
    at walkObject (/home/perrin4869/univapay/services-typescript/node_modules/sinon/lib/sinon/util/core/walk-object.js:47:15)
    at stub (/home/perrin4869/univapay/services-typescript/node_modules/sinon/lib/sinon/stub.js:103:16)
    at createStubInstance (/home/perrin4869/univapay/services-typescript/node_modules/sinon/lib/sinon/create-stub-instance.js:19:27)
    at createStubInstance (/home/perrin4869/univapay/services-typescript/node_modules/sinon/lib/sinon/sandbox.js:112:49)
```

This shouldn't really be a breaking change though, I kept the cjs version as before, any any system that's actually supported and running the `esm` version under node should also support the es2022 syntax, and allow us to test using sinon in the services repo