### PR TITLE
Fix renew event

### DIFF
--- a/src/resources/WebHooks.ts
+++ b/src/resources/WebHooks.ts
@@ -22,8 +22,8 @@ export enum WebHookTrigger {
     REFUND_FINISHED = "refund_finished",
     CANCEL_FINISHED = "cancel_finished",
     RECURRING_TOKEN_DELETED = "recurring_token_deleted",
-    RECURRING_TOKEN_RENEW = "recurring_token_renew",
     CUSTOMS_DECLARATION_FINISHED = "customs_declaration_finished",
+    TOKEN_REPLACED = "token_replaced", // Also use the token renew
     TOKEN_UPDATED = "token_updated",
     TOKEN_CVV_AUTH_UPDATED = "token_cvv_auth_updated",
     TOKEN_CVV_AUTH_CHECK_UPDATED = "token_cvv_auth_check_updated",


### PR DESCRIPTION
Updates https://github.com/univapaycast/univapay-console/issues/3580

Seems that the webhook event was the wrong one after discussing with API. I got confused with the payment event.