### PR TITLE
Modify API to accommodate cookie authentication

### DIFF
--- a/src/api/RestAPI.ts
+++ b/src/api/RestAPI.ts
@@ -117,6 +117,7 @@ export interface AuthParams {
     secret?: string;
     idempotentKey?: string;
     origin?: string;
+    useCredentials?: boolean;
 
     // Deprecated
     authToken?: string;
@@ -244,6 +245,7 @@ export class RestAPI extends EventEmitter {
         const params: RequestInit = {
             headers: this.getHeaders(data, auth, payload, acceptType),
             method,
+            ...(auth?.useCredentials ? { credentials: "include" } : {}),
         };
 
         const request: Request = new Request(


### PR DESCRIPTION
Related to: https://github.com/univapaycast/call-center/issues/12

I decided to modify the API to accommodate for the case of cookie authorization as per the call-center new API documentation.

https://github.com/univapaycast/call-center/blob/develop/openapi/openapi.yaml
