### PR TITLE
Allow body transfer encoding overrides

### DIFF
--- a/src/api/RestAPI.ts
+++ b/src/api/RestAPI.ts
@@ -163,7 +163,7 @@ export type ApiSendOptions = {
     /**
      * Overrides default body transfer encoding of the request.
      *
-     * Note: Can not for for GET and HEAD request
+     * Note: Can not for GET and HEAD request
      *
      * Default is "message-body" for DELETE, HEAD and GET and "entity-body" for all other call methods.
      */
@@ -267,7 +267,7 @@ export class RestAPI extends EventEmitter {
 
         const payload: boolean =
             bodyTransferEncoding === "entity"
-                ? true && ![HTTPMethod.GET, HTTPMethod.HEAD].includes(method)
+                ? ![HTTPMethod.GET, HTTPMethod.HEAD].includes(method)
                 : bodyTransferEncoding === "message"
                   ? false
                   : ![HTTPMethod.GET, HTTPMethod.HEAD, HTTPMethod.DELETE].includes(method);


### PR DESCRIPTION
It was asked for the services multiple time and backend was changed but it is only a matter of time before customer want to do the same as the web specifications allow for pretty wild usage.