### PR TITLE
Do not include ptional parameter in list path required parameters

### DIFF
--- a/src/resources/Resource.ts
+++ b/src/resources/Resource.ts
@@ -32,14 +32,13 @@ export type DefinedRoute = (data?: unknown, auth?: AuthParams, pathParams?: Reco
  * @param path The full path to compile, e.g. `(/merchant/:merchantId)/store/:storeId`
  * @param pathParams Object of params to fill into the path, e.g. `{ merchantId: "abc" }`
  */
-function compilePath(path: string, pathParams: Record<string, string>): string {
-    return path
-        .replace(/\((\w|:|\/)+\)/gi, (o: string) => {
+const compilePath = (path: string, pathParams: Record<string, string>): string =>
+    path
+        .replace(/\((\w|:|-|\/)+\)/gi, (o: string) => {
             const part = o.replace(/:(\w+)/gi, (s: string, p: string) => pathParams[p] || s);
             return part.indexOf(":") === -1 ? part.replace(/\(|\)/g, "") : "";
         })
         .replace(/:(\w+)/gi, (s: string, p: string) => pathParams[p] || s);
-}
 
 type ObjectType =
     | "array"
@@ -115,7 +114,7 @@ export abstract class Resource extends EventEmitter {
             const url = compilePath(path, pathParams);
 
             // Validate required path parameters
-            const firstMissingPathParam = url.match(/:([a-z]+)(?![^()]*\))/gi)?.[0];
+            const firstMissingPathParam = url.match(/:([a-z]+)/gi)?.[0];
             if (firstMissingPathParam) {
                 const error = fromError(new PathParameterError(firstMissingPathParam.replace(":", "")));
                 return Promise.reject(error);

--- a/test/specs/common/resource.specs.ts
+++ b/test/specs/common/resource.specs.ts
@@ -8,11 +8,18 @@ import { Resource } from "../../../src/resources/Resource.js";
 
 describe("Common > Resource", () => {
     const recordPathMatcher = pathToRegexMatcher(`${testEndpoint}/test/:fooPart(foo/[^/]+)?/bar/:bar`);
+    const recordWithDashInPatPathMatcher = pathToRegexMatcher(
+        `${testEndpoint}/test/:fooPart(foo-foos/[^/]+)?/bar/:bar`,
+    );
     class CustomResource extends Resource {
         static routeBase = "/test";
 
         get(bar?: string, foo?: string): Promise<unknown> {
             return this.defineRoute(HTTPMethod.GET, "/test(/foo/:foo)/bar/:bar")(null, undefined, { foo, bar });
+        }
+
+        getWithDashInPath(bar?: string, foo?: string): Promise<unknown> {
+            return this.defineRoute(HTTPMethod.GET, "/test(/foo-foos/:foo)/bar/:bar")(null, undefined, { foo, bar });
         }
 
         postObject(bar?: string, foo?: string): Promise<unknown> {
@@ -52,6 +59,11 @@ describe("Common > Resource", () => {
         it("should get response with optional parameter missing", async () => {
             fetchMock.getOnce(recordPathMatcher, dummyResponse);
             await expect(resource.get("bar")).to.become(dummyResponse.body);
+        });
+
+        it("should get response with optional parameter missing with dash", async () => {
+            fetchMock.getOnce(recordWithDashInPatPathMatcher, dummyResponse);
+            await expect(resource.getWithDashInPath("bar")).to.become(dummyResponse.body);
         });
 
         it("should get response with all parameters", async () => {


### PR DESCRIPTION
Issue found while working on MCP integration: https://github.com/univapaycast/univapay-form-checkout/issues/1284

The problem is that the frontend required validation was kicking in for optional parameters resulting in valid routes to be inaccessible:

e.g, calling this route would result in an error when the optional `foo` parameter is not provided:
```
${PLATFORM_PART}${MERCHANT_PART}(/foos/:foo)/bars/bar
```