### PR TITLE
Remove no longer used MCP fields from ChargeItem

### DIFF
--- a/src/resources/Charges.ts
+++ b/src/resources/Charges.ts
@@ -119,8 +119,6 @@ export interface ChargeItem<T extends Metadata = Metadata> {
     };
     mcp?: {
         enabled: boolean;
-        amount?: number;
-        currency?: string;
     };
 
     ledgerId?: string;


### PR DESCRIPTION
Updates https://github.com/univapaycast/univapay-admin-console/issues/2474

Step 1 of the above linked issue.

All other steps have been implemented on my local machine and tested with these changes (node private and admin-console)