### PR TITLE
Fix broken npm description and dead build badge

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -14,7 +14,7 @@
 [cla-url]: https://cla-assistant.io/univapay/univapay-node
 [shield-node]: https://img.shields.io/node/v/univapay-node.svg
 [shield-npm]: https://img.shields.io/npm/v/univapay-node.svg
-[shield-build]: https://img.shields.io/github/workflow/status/univapay/univapay-node/test/master
+[shield-build]: https://img.shields.io/github/actions/workflow/status/univapay/univapay-node/continuous-integration-workflow.yml?branch=master
 [shield-downloads]: https://img.shields.io/npm/dm/univapay-node.svg
 [shield-license]: https://img.shields.io/npm/l/univapay-node.svg
 [shield-coverage]: https://coveralls.io/repos/github/univapay/univapay-node/badge.svg?branch=master

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [cla-url]: https://cla-assistant.io/univapay/univapay-node
 [shield-node]: https://img.shields.io/node/v/univapay-node.svg
 [shield-npm]: https://img.shields.io/npm/v/univapay-node.svg
-[shield-build]: https://img.shields.io/github/workflow/status/univapay/univapay-node/test/master
+[shield-build]: https://img.shields.io/github/actions/workflow/status/univapay/univapay-node/continuous-integration-workflow.yml?branch=master
 [shield-downloads]: https://img.shields.io/npm/dm/univapay-node.svg
 [shield-license]: https://img.shields.io/npm/l/univapay-node.svg
 [shield-coverage]: https://coveralls.io/repos/github/univapay/univapay-node/badge.svg?branch=master

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "univapay-node",
   "version": "4.0.163",
+  "description": "UnivaPay SDK library for Node.js",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Two small fixes to the package metadata / README.

**1. Missing `description` in `package.json`**

`package.json` has no `description` field, so npm falls back to text from the README and the published package shows a broken description on npmjs.com:

```
$ npm view univapay-node description
[node]: https://nodejs.org/ [npm]: https://www.npmjs.com/ [yarn]: https://yarnpkg.com/ [we...
```

Added `"description": "UnivaPay SDK library for Node.js"` (matching the wording used by the sibling SDKs).

**2. Dead build badge**

The build badge uses `img.shields.io/github/workflow/status/...`, an endpoint shields.io retired when GitHub changed its Actions API. It no longer renders a build status (it returns an error badge). Updated it to the current `github/actions/workflow/status/...` form pointing at `continuous-integration-workflow.yml`. If you'd prefer it to track a different workflow (e.g. `unit-test.yml` or `build.yml`), happy to change it.