### PR TITLE
Fix long polling continuing after timeout and interval function only computed once

### DIFF
--- a/src/api/RestAPI.ts
+++ b/src/api/RestAPI.ts
@@ -424,11 +424,16 @@ export class RestAPI extends EventEmitter {
 
         return execRequest(async () => {
             let internalErrorCount = 0;
+            let timedOut = false;
 
-            const computedInterval = typeof interval === "number" ? interval : interval();
-            const sleepInterval = () => new Promise((resolve) => setTimeout(resolve, computedInterval));
+            const sleepInterval = () =>
+                new Promise((resolve) => setTimeout(resolve, typeof interval === "number" ? interval : interval()));
 
             const repeater = async (): Promise<Response | null> => {
+                if (timedOut) {
+                    return null;
+                }
+
                 if (browserSkipCallForInactiveTabs && document?.hidden) {
                     await sleepInterval();
                     return repeater();
@@ -462,7 +467,10 @@ export class RestAPI extends EventEmitter {
                 }
             };
 
-            return pTimeout(repeater(), timeout, new TimeoutError(timeout));
+            return pTimeout(repeater(), timeout, () => {
+                timedOut = true;
+                throw new TimeoutError(timeout);
+            });
         });
     }
 

--- a/test/specs/api.specs.ts
+++ b/test/specs/api.specs.ts
@@ -14,6 +14,7 @@ import {
 import { APIError, ResponseErrorCode } from "../../src/errors/APIError.js";
 import { fromError } from "../../src/errors/parser.js";
 import { ResponseError } from "../../src/errors/RequestResponseError.js";
+import { TimeoutError } from "../../src/errors/TimeoutError.js";
 import { isBlob } from "../../src/utils/object.js";
 import { testEndpoint } from "../utils/index.js";
 
@@ -673,5 +674,51 @@ describe("API", function () {
             requestInit: { redirect: "manual" },
         });
         expect(response).to.eql(okResponse);
+    });
+
+    describe("longPolling", function () {
+        let clock: sinon.SinonFakeTimers;
+
+        beforeEach(function () {
+            clock = sinon.useFakeTimers();
+        });
+
+        afterEach(function () {
+            clock.restore();
+        });
+
+        it("should stop calling the executor after timeout", async function () {
+            const api: RestAPI = new RestAPI({ endpoint: testEndpoint });
+            const execute = sinon.spy(() => Promise.resolve({ ok: false }));
+
+            const request = api.longPolling(execute, {
+                successCondition: ({ ok }: { ok: boolean }) => ok,
+                interval: 100,
+                timeout: 1000,
+            });
+
+            await clock.tickAsync(1000);
+            await expect(request).to.eventually.be.rejectedWith(TimeoutError);
+
+            const callCountAtTimeout = execute.callCount;
+            await clock.tickAsync(2000);
+            expect(execute.callCount).to.eql(callCountAtTimeout);
+        });
+
+        it("should compute the poll interval on every iteration", async function () {
+            const api: RestAPI = new RestAPI({ endpoint: testEndpoint });
+            let executeCount = 0;
+            const execute = () => Promise.resolve({ ok: ++executeCount >= 3 });
+            const interval = sinon.spy(() => 100);
+
+            const request = api.longPolling(execute, {
+                successCondition: ({ ok }: { ok: boolean }) => ok,
+                interval,
+            });
+
+            await clock.tickAsync(300);
+            await expect(request).to.become({ ok: true });
+            expect(interval.callCount).to.eql(2);
+        });
     });
 });


### PR DESCRIPTION
先日 #1315 をマージいただいた者です。その際に SDK のコードを読んでいて、`RestAPI.longPolling`（charges / refunds / cancels / subscriptions の `poll()` が使用）に 2 つ問題を見つけたので、修正とテストを送ります。

## 問題 1: タイムアウト後もポーリングが止まらない

`pTimeout` は外側の Promise を `TimeoutError` で reject しますが、内部の `repeater()` の再帰は止まらないため、成功条件が満たされない限り**タイムアウト後も executor（= API 呼び出し）が無期限に実行され続けます**。

再現（p-timeout@4 で確認）:

```
timeout(100ms) 時点で 5 回呼び出し → TimeoutError 送出後の 500ms でさらに 23 回
```

`charges.poll()` がタイムアウトした後も、呼び出し元からは見えないゴーストポーリングが API を叩き続ける形になります。サーバーサイドで poll を多用するアプリでは、API 負荷・レートリミット消費につながります。

## 問題 2: `interval` に関数を渡しても 1 回しか評価されない

`PollParams.interval` は「Interval between polls or **function to compute the interval**」と定義されていますが、実装ではループ開始前に 1 度だけ評価されるため、動的な間隔（バックオフ等）が機能しません。

## 修正

- `pTimeout` の fallback 関数でタイムアウトをフラグに記録し、次のイテレーションで repeater を停止（外側へは従来どおり `TimeoutError` を送出）
- `interval` の評価を毎スリープ時に移動

## テスト

回帰テストを 2 件追加しました（`test/specs/api.specs.ts` の `longPolling` describe）。修正前のコードでは両方 fail、修正後は pass することを確認しています。既存テスト 202 件もすべて通過しています（Node 22）。
